### PR TITLE
[#12] Render assistant Markdown in WebUI chat

### DIFF
--- a/.agent/plans/12-webui-markdown-rendering.md
+++ b/.agent/plans/12-webui-markdown-rendering.md
@@ -1,0 +1,50 @@
+﻿# Plan: Issue #12 - Render assistant Markdown in WebUI chat
+
+## Execution Contract
+- Issue: #12
+- Branch: `feature/12-webui-markdown-chat`
+- Plan file: `.agent/plans/12-webui-markdown-rendering.md`
+
+## Goal
+Render assistant responses as Markdown in the WebUI chat while keeping user messages as plain text.
+
+## Acceptance Criteria
+- [ ] Assistant messages render markdown consistently.
+- [ ] Code blocks are syntax-highlighted or visually distinct.
+- [ ] Links are styled and open in a new tab.
+- [ ] Performance remains acceptable for long messages.
+
+## Touch Points
+- `webui/src/components/Chat.svelte`
+- `webui/src/lib/` (new markdown utility module)
+- `README.md` (if behavior note is needed)
+
+## Implementation Slices
+1. **Markdown utility layer**
+   - Add a small utility to parse Markdown with `marked`.
+   - Ensure links render with `target="_blank"` + `rel="noopener noreferrer"`.
+   - Escape raw HTML input before parsing to avoid unsafe HTML injection.
+   - Add formatting helpers for plain-text fallback.
+
+2. **Chat rendering integration**
+   - Render assistant role messages with parsed HTML (`{@html ...}` from utility).
+   - Keep user role messages plain text.
+   - Keep existing timestamps/layout unchanged.
+
+3. **Styling for readability**
+   - Add styles for headings, paragraphs, lists, blockquotes, inline code, fenced code, links, and tables in chat bubbles.
+   - Ensure code blocks are visually distinct and scrollable.
+
+4. **Validation**
+   - `npm run type-check`
+   - `npm --prefix webui run check`
+   - `npm test`
+   - `npm run lint`
+   - `npm run build`
+
+## Risks / Edge Cases
+- Very long messages can increase render cost; avoid extra parsing passes and parse once per message render.
+- `{@html}` safety: enforce escaping before markdown parse to keep rendering predictable.
+
+## Rollback
+- Revert markdown utility + Chat rendering block to restore plain text rendering immediately.

--- a/.agent/reports/execution-reports/2026-02-03-12-webui-markdown-rendering.md
+++ b/.agent/reports/execution-reports/2026-02-03-12-webui-markdown-rendering.md
@@ -1,0 +1,39 @@
+﻿# Execution Report - Issue #12 Markdown Rendering in WebUI Chat
+
+## Meta
+- Related Issue: #12
+- Branch: `feature/12-webui-markdown-chat`
+- Plan file: `.agent/plans/12-webui-markdown-rendering.md`
+- Files modified:
+  - `webui/src/components/Chat.svelte`
+  - `README.md`
+- Files added:
+  - `webui/src/lib/markdown.ts`
+  - `.agent/plans/12-webui-markdown-rendering.md`
+
+## What changed
+- Added Markdown rendering utility based on `marked` in `webui/src/lib/markdown.ts`.
+- Escaped raw HTML before parsing markdown to prevent raw HTML injection in chat output.
+- Enforced safe external links by adding `target="_blank"` and `rel="noopener noreferrer"`.
+- Updated chat rendering in `webui/src/components/Chat.svelte`:
+  - Assistant messages now render markdown HTML.
+  - User messages remain plain text.
+  - Added lightweight markdown render caching per message content.
+- Added message markdown typography/styling for lists, headings, blockquotes, inline code, code blocks, links, and tables.
+- Updated README WebUI feature list with markdown-rendering capability.
+
+## Plan adherence
+- Matched planned slices for markdown utility, chat integration, and styling.
+- Divergence: skipped automated webui markdown unit tests due current repo test runner being node/jest-only and not configured for webui ESM dependency test execution. Covered behavior with type/build checks plus direct utility runtime check.
+
+## Verification
+- `npm run type-check` -> PASS
+- `npm --prefix webui run check` -> PASS (0 errors, 0 warnings)
+- `npm run lint` -> PASS (0 errors, existing warnings baseline)
+- `npm test` -> PASS (11/11 suites, 62/62 tests)
+- `npm run build` -> PASS
+- Direct runtime check:
+  - `npx tsx -` importing `webui/src/lib/markdown.ts` and rendering sample markdown -> produced expected heading/link/code HTML.
+
+## Follow-ups
+- Optional: add dedicated webui unit test runner (Vitest) for frontend utility tests in future UI-focused issue.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ You must configure **at least one** platform to interact with your AI assistant.
 - Workflow palette with grouped commands, filtering, and optional arguments
 - GitHub issue linking (`/context link-issue`) with persistent conversation context
 - Telemetry panel with per-assistant request/latency/success metrics
+- Assistant message markdown rendering with styled code blocks and safe external links
 
 **Configuration:**
 

--- a/webui/src/components/Chat.svelte
+++ b/webui/src/components/Chat.svelte
@@ -11,6 +11,7 @@
   import CommandPalette from './CommandPalette.svelte';
   import ContextSelector from './ContextSelector.svelte';
   import StatsPanel from './StatsPanel.svelte';
+  import { renderAssistantMarkdown } from '../lib/markdown';
 
   interface Conversation {
     id: string;
@@ -36,6 +37,7 @@
   let joined = false;
   let showControls = false;
   const METADATA_SYNC_DELAY_MS = 1000;
+  const markdownCache = new Map<string, string>();
 
   async function refreshConversations(preferredId?: string) {
     try {
@@ -211,6 +213,16 @@
     }, METADATA_SYNC_DELAY_MS);
   }
 
+  function renderAssistantContent(content: string): string {
+    const cached = markdownCache.get(content);
+    if (cached) {
+      return cached;
+    }
+    const rendered = renderAssistantMarkdown(content);
+    markdownCache.set(content, rendered);
+    return rendered;
+  }
+
   afterUpdate(() => {
     if (messagesDiv) messagesDiv.scrollTop = messagesDiv.scrollHeight;
   });
@@ -307,7 +319,11 @@
         {#each currentMessages as msg}
           <div class="message-wrapper {msg.payload.role}">
             <div class="message-bubble shadow">
-              <div class="content">{msg.payload.content}</div>
+              {#if msg.payload.role === 'assistant'}
+                <div class="content markdown">{@html renderAssistantContent(String(msg.payload.content ?? ''))}</div>
+              {:else}
+                <div class="content">{msg.payload.content}</div>
+              {/if}
               <div class="meta">
                 {new Date(msg.payload.timestamp).toLocaleTimeString([], {
                   hour: '2-digit',
@@ -673,6 +689,86 @@
   .content {
     white-space: pre-wrap;
     word-break: break-word;
+  }
+
+  .content.markdown {
+    white-space: normal;
+  }
+
+  .content.markdown :global(p) {
+    margin: 0.5rem 0;
+    line-height: 1.6;
+  }
+
+  .content.markdown :global(ul),
+  .content.markdown :global(ol) {
+    margin: 0.4rem 0 0.4rem 1.2rem;
+    padding: 0;
+  }
+
+  .content.markdown :global(li) {
+    margin: 0.2rem 0;
+  }
+
+  .content.markdown :global(h1),
+  .content.markdown :global(h2),
+  .content.markdown :global(h3),
+  .content.markdown :global(h4) {
+    margin: 0.75rem 0 0.4rem;
+    line-height: 1.3;
+  }
+
+  .content.markdown :global(pre) {
+    margin: 0.6rem 0;
+    padding: 0.7rem 0.8rem;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid var(--border-subtle);
+    overflow-x: auto;
+  }
+
+  .content.markdown :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+  }
+
+  .content.markdown :global(:not(pre) > code) {
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .content.markdown :global(blockquote) {
+    margin: 0.6rem 0;
+    padding: 0.35rem 0.7rem;
+    border-left: 3px solid var(--accent-blue);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-secondary);
+  }
+
+  .content.markdown :global(a) {
+    color: var(--accent-blue);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .content.markdown :global(a:hover) {
+    color: var(--accent-blue-hover);
+  }
+
+  .content.markdown :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.7rem 0;
+    font-size: 0.9em;
+  }
+
+  .content.markdown :global(th),
+  .content.markdown :global(td) {
+    border: 1px solid var(--border-subtle);
+    padding: 0.35rem 0.5rem;
+    text-align: left;
   }
 
   .meta {

--- a/webui/src/lib/markdown.ts
+++ b/webui/src/lib/markdown.ts
@@ -1,0 +1,34 @@
+import { marked } from 'marked';
+
+marked.setOptions({
+  gfm: true,
+  breaks: true,
+});
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function withSafeLinkAttributes(html: string): string {
+  return html.replace(/<a\s+([^>]*href="[^"]+"[^>]*)>/g, (_match, attrs: string) => {
+    let next = attrs;
+    if (!/\btarget=/.test(next)) {
+      next += ' target="_blank"';
+    }
+    if (!/\brel=/.test(next)) {
+      next += ' rel="noopener noreferrer"';
+    }
+    return `<a ${next}>`;
+  });
+}
+
+export function renderAssistantMarkdown(content: string): string {
+  const escaped = escapeHtml(content);
+  const parsed = marked.parse(escaped, { async: false });
+  return withSafeLinkAttributes(parsed);
+}


### PR DESCRIPTION
﻿## What/Why
- render assistant chat responses as Markdown in WebUI, while preserving plain-text rendering for user messages
- improve readability with markdown-specific styling for lists, headings, blockquotes, inline code, fenced code, links, and tables
- enforce safer link behavior (`target="_blank"` + `rel="noopener noreferrer"`) and escape raw HTML before markdown parsing

## Implementation
- Added `webui/src/lib/markdown.ts` for markdown rendering and safe link attribute handling.
- Updated `webui/src/components/Chat.svelte`:
  - assistant messages use rendered markdown HTML
  - user messages remain plain text
  - lightweight content-cache for rendered markdown output
- Updated docs in `README.md` and added plan/report artifacts for Issue #12 workflow.

## How tested
- `npm run type-check`
- `npm --prefix webui run check`
- `npm run lint`
- `npm test`
- `npm run build`
- Runtime utility check via `npx tsx` importing `webui/src/lib/markdown.ts` with sample markdown payload.

## Risks
- Very large assistant messages may still incur render overhead despite cache.
- This keeps markdown behavior scoped to assistant messages only by design.

Fixes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Assistant messages in the WebUI chat now render with markdown formatting, including styled code blocks, headings, lists, tables, and blockquotes for improved readability
  * External links open safely in new tabs with proper security attributes

* **Documentation**
  * Updated README to reflect markdown rendering enhancement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->