### PR TITLE
[#11] WebUI layout flexibility and responsive design

### DIFF
--- a/.agent/plans/11-webui-layout-responsiveness.md
+++ b/.agent/plans/11-webui-layout-responsiveness.md
@@ -1,0 +1,38 @@
+﻿# Plan: Issue #11 - WebUI layout flexibility and responsive design
+
+## Execution Contract
+- Issue: #11
+- Branch: `feature/11-webui-layout-responsive`
+- Plan file: `.agent/plans/11-webui-layout-responsiveness.md`
+
+## Goal
+Make WebUI layout adaptive and productivity-friendly by allowing explorer/preview toggles, responsive narrow-screen behavior, and persisted layout state.
+
+## Acceptance Criteria
+- [ ] Users can toggle explorer and preview visibility independently.
+- [ ] Chat panel expands when panels are hidden or collapsed.
+- [ ] Layout adapts to narrow screens with a stacked view or drawer.
+- [ ] Panel state is persisted between reloads.
+- [ ] Keyboard and mouse interactions remain accessible.
+
+## Touch Points
+- `webui/src/App.svelte`
+- `README.md` (feature note)
+
+## Implementation Slices
+1. Add layout state model (`showExplorer`, `showPreview`, `mobilePanel`) and localStorage persistence.
+2. Restructure main shell into independently toggleable explorer/chat/preview panes.
+3. Add responsive mode with panel tabs on narrow viewports.
+4. Ensure controls are accessible (`button`, `aria-pressed`, keyboard focus behavior).
+5. Validate + document behavior.
+
+## Verification
+- `npm --prefix webui run check`
+- `npm run type-check`
+- `npm run lint`
+- `npm test`
+- `npm run build`
+
+## Risks / Notes
+- Large layout refactor concentrated in one file; keep follow-up style cleanup scoped.
+- Persisted layout is per-browser local state by design.

--- a/.agent/reports/execution-reports/2026-02-03-11-webui-layout-responsiveness.md
+++ b/.agent/reports/execution-reports/2026-02-03-11-webui-layout-responsiveness.md
@@ -1,0 +1,32 @@
+﻿# Execution Report - Issue #11 WebUI layout flexibility and responsive design
+
+## Meta
+- Related Issue: #11
+- Branch: `feature/11-webui-layout-responsive`
+- Plan file: `.agent/plans/11-webui-layout-responsiveness.md`
+- Files modified:
+  - `webui/src/App.svelte`
+  - `README.md`
+- Files added:
+  - `.agent/plans/11-webui-layout-responsiveness.md`
+
+## What changed
+- Refactored WebUI shell into independently toggleable explorer/chat/preview panes.
+- Added toolbar controls to collapse/expand explorer and preview panels.
+- Added narrow-screen responsive mode with panel tab switching (Files / Chat / Preview).
+- Added localStorage persistence for layout state (`showExplorer`, `showPreview`, `mobilePanel`).
+- Kept keyboard/mouse accessibility via semantic button controls and `aria-pressed`/`aria-selected` states.
+
+## Plan adherence
+- Implemented all planned slices in a single focused refactor in `webui/src/App.svelte`.
+- Divergence: manual browser QA via MCP Playwright was blocked by auth credential context errors (`ERR_INVALID_AUTH_CREDENTIALS`) in tool runtime; functionality validated via static checks and test suite.
+
+## Verification
+- `npm --prefix webui run check` -> PASS (0 errors, 0 warnings)
+- `npm run type-check` -> PASS
+- `npm run lint` -> PASS (0 errors, existing warnings baseline)
+- `npm test` -> PASS (11/11 suites, 62/62 tests)
+- `npm run build` -> PASS
+
+## Follow-ups
+- Optional enhancement: add draggable pane resizing and persisted pane widths in a follow-up issue.

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ You must configure **at least one** platform to interact with your AI assistant.
 - GitHub issue linking (`/context link-issue`) with persistent conversation context
 - Telemetry panel with per-assistant request/latency/success metrics
 - Assistant message markdown rendering with styled code blocks and safe external links
+- Responsive panel controls with persisted explorer/preview visibility and mobile panel switching
 
 **Configuration:**
 

--- a/webui/src/App.svelte
+++ b/webui/src/App.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+﻿<script lang="ts">
   import { onMount } from 'svelte';
   import { API } from './lib/api';
   import Login from './components/Login.svelte';
@@ -12,19 +12,115 @@
   let currentFile = '';
   let currentContent = '';
   let previewLoading = false;
+  let showExplorer = true;
+  let showPreview = true;
+  let isNarrowScreen = false;
+  let mobilePanel: 'chat' | 'explorer' | 'preview' = 'chat';
+  let layoutInitialized = false;
 
-  onMount(async () => {
-    if (authenticated) {
-      try {
-        await API.getConversations(); // Validate token
-      } catch (e) {
-        authenticated = false;
+  const LAYOUT_STORAGE_KEY = 'webui.layout.v1';
+  const NARROW_LAYOUT_QUERY = '(max-width: 1100px)';
+
+  function loadLayoutState(): void {
+    try {
+      const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as {
+        showExplorer?: boolean;
+        showPreview?: boolean;
+        mobilePanel?: 'chat' | 'explorer' | 'preview';
+      };
+      if (typeof parsed.showExplorer === 'boolean') {
+        showExplorer = parsed.showExplorer;
       }
+      if (typeof parsed.showPreview === 'boolean') {
+        showPreview = parsed.showPreview;
+      }
+      if (parsed.mobilePanel === 'chat' || parsed.mobilePanel === 'explorer' || parsed.mobilePanel === 'preview') {
+        mobilePanel = parsed.mobilePanel;
+      }
+    } catch {
+      // Ignore malformed state.
     }
-    loading = false;
+  }
+
+  function saveLayoutState(): void {
+    if (!layoutInitialized) return;
+    localStorage.setItem(
+      LAYOUT_STORAGE_KEY,
+      JSON.stringify({
+        showExplorer,
+        showPreview,
+        mobilePanel,
+      })
+    );
+  }
+
+  function syncViewport(mql: MediaQueryList | MediaQueryListEvent): void {
+    isNarrowScreen = mql.matches;
+    if (mobilePanel === 'explorer' && !showExplorer) {
+      mobilePanel = 'chat';
+    }
+    if (mobilePanel === 'preview' && !showPreview) {
+      mobilePanel = 'chat';
+    }
+  }
+
+  function toggleExplorer(): void {
+    showExplorer = !showExplorer;
+    if (!showExplorer && mobilePanel === 'explorer') {
+      mobilePanel = 'chat';
+    }
+  }
+
+  function togglePreview(): void {
+    showPreview = !showPreview;
+    if (!showPreview && mobilePanel === 'preview') {
+      mobilePanel = 'chat';
+    }
+  }
+
+  function getDesktopColumns(): string {
+    const columns: string[] = [];
+    if (showExplorer) {
+      columns.push('minmax(240px, 320px)');
+    }
+    columns.push('minmax(420px, 1fr)');
+    if (showPreview) {
+      columns.push('minmax(320px, 1fr)');
+    }
+    return columns.join(' ');
+  }
+
+  $: desktopColumns = getDesktopColumns();
+  $: saveLayoutState();
+
+  onMount(() => {
+    loadLayoutState();
+    const mql = window.matchMedia(NARROW_LAYOUT_QUERY);
+    syncViewport(mql);
+    const onViewportChange = (event: MediaQueryListEvent) => syncViewport(event);
+    mql.addEventListener('change', onViewportChange);
+
+    void (async () => {
+      if (authenticated) {
+        try {
+          await API.getConversations();
+        } catch {
+          authenticated = false;
+        }
+      }
+
+      layoutInitialized = true;
+      loading = false;
+    })();
+
+    return () => {
+      mql.removeEventListener('change', onViewportChange);
+    };
   });
 
-  async function handleFileSelect(event: CustomEvent) {
+  async function handleFileSelect(event: CustomEvent): Promise<void> {
     const file = event.detail;
     currentFile = file.path;
     previewLoading = true;
@@ -49,38 +145,129 @@
   {:else if !authenticated}
     <Login />
   {:else}
-    <div class="layout">
-      <div class="sidebar">
-        <div class="sidebar-section files">
-          <div class="section-header">
-            <h3>Explorer</h3>
-          </div>
-          <div class="section-content">
-            <FileTree on:select={handleFileSelect} />
-          </div>
+    <div class="workspace-shell">
+      <div class="workspace-toolbar">
+        <div class="toolbar-group">
+          <button class="toggle-btn" class:active={showExplorer} aria-pressed={showExplorer} on:click={toggleExplorer}>
+            Explorer
+          </button>
+          <button class="toggle-btn" class:active={showPreview} aria-pressed={showPreview} on:click={togglePreview}>
+            Preview
+          </button>
         </div>
-        <div class="sidebar-section chat">
-          <div class="section-header">
-            <h3>Remote Agent Chat</h3>
+
+        {#if isNarrowScreen}
+          <div class="toolbar-group mobile-tabs" role="tablist" aria-label="Active panel">
+            {#if showExplorer}
+              <button
+                class="tab-btn"
+                class:active={mobilePanel === 'explorer'}
+                role="tab"
+                aria-selected={mobilePanel === 'explorer'}
+                on:click={() => (mobilePanel = 'explorer')}
+              >
+                Files
+              </button>
+            {/if}
+            <button
+              class="tab-btn"
+              class:active={mobilePanel === 'chat'}
+              role="tab"
+              aria-selected={mobilePanel === 'chat'}
+              on:click={() => (mobilePanel = 'chat')}
+            >
+              Chat
+            </button>
+            {#if showPreview}
+              <button
+                class="tab-btn"
+                class:active={mobilePanel === 'preview'}
+                role="tab"
+                aria-selected={mobilePanel === 'preview'}
+                on:click={() => (mobilePanel = 'preview')}
+              >
+                Preview
+              </button>
+            {/if}
           </div>
-          <div class="section-content">
-            <Chat />
-          </div>
-        </div>
+        {/if}
       </div>
-      <div class="preview-area">
-        {#if previewLoading}
-          <div class="loading-preview glass">
-            <div class="spinner"></div>
-            <span>Loading {currentFile.split('/').pop()}...</span>
-          </div>
-        {:else if currentFile}
-          <Preview path={currentFile} content={currentContent} />
+
+      <div class="layout" style:--desktop-cols={desktopColumns}>
+        {#if !isNarrowScreen}
+          {#if showExplorer}
+            <aside class="pane explorer-pane">
+              <div class="section-header">
+                <h3>Explorer</h3>
+              </div>
+              <div class="section-content">
+                <FileTree on:select={handleFileSelect} />
+              </div>
+            </aside>
+          {/if}
+
+          <section class="pane chat-pane">
+            <div class="section-header">
+              <h3>Remote Agent Chat</h3>
+            </div>
+            <div class="section-content">
+              <Chat />
+            </div>
+          </section>
+
+          {#if showPreview}
+            <section class="pane preview-pane">
+              {#if previewLoading}
+                <div class="loading-preview glass">
+                  <div class="spinner"></div>
+                  <span>Loading {currentFile.split('/').pop()}...</span>
+                </div>
+              {:else if currentFile}
+                <Preview path={currentFile} content={currentContent} />
+              {:else}
+                <div class="placeholder">
+                  <div class="icon">Preview</div>
+                  <p>Select a file from the explorer to preview content</p>
+                </div>
+              {/if}
+            </section>
+          {/if}
         {:else}
-          <div class="placeholder">
-            <div class="icon">🛰️</div>
-            <p>Select a file from the explorer to preview content</p>
-          </div>
+          {#if mobilePanel === 'explorer' && showExplorer}
+            <aside class="pane explorer-pane mobile-pane">
+              <div class="section-header">
+                <h3>Explorer</h3>
+              </div>
+              <div class="section-content">
+                <FileTree on:select={handleFileSelect} />
+              </div>
+            </aside>
+          {:else if mobilePanel === 'preview' && showPreview}
+            <section class="pane preview-pane mobile-pane">
+              {#if previewLoading}
+                <div class="loading-preview glass">
+                  <div class="spinner"></div>
+                  <span>Loading {currentFile.split('/').pop()}...</span>
+                </div>
+              {:else if currentFile}
+                <Preview path={currentFile} content={currentContent} />
+              {:else}
+                <div class="placeholder">
+                  <div class="icon">Preview</div>
+                  <p>Select a file from the explorer to preview content</p>
+                </div>
+              {/if}
+            </section>
+          {:else}
+            <section class="pane chat-pane mobile-pane">
+              <div class="section-header">
+                <h3>Remote Agent Chat</h3>
+              </div>
+              <div class="section-content">
+                <Chat />
+              </div>
+            </section>
+          {/if}
         {/if}
       </div>
     </div>
@@ -121,35 +308,81 @@
     }
   }
 
-  .layout {
-    display: grid;
-    grid-template-columns: var(--sidebar-width) 1fr;
+  .workspace-shell {
     width: 100vw;
     height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-primary);
   }
 
-  .sidebar {
+  .workspace-toolbar {
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 0 10px;
     background: var(--bg-secondary);
-    border-right: 1px solid var(--border-subtle);
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    overflow: hidden;
-  }
-
-  .sidebar-section {
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-  }
-
-  .sidebar-section.files {
-    height: 40%;
     border-bottom: 1px solid var(--border-subtle);
   }
 
-  .sidebar-section.chat {
+  .toolbar-group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .toggle-btn,
+  .tab-btn {
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-secondary);
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: var(--transition-fast);
+  }
+
+  .toggle-btn:hover,
+  .tab-btn:hover {
+    color: var(--text-primary);
+    border-color: var(--accent-blue);
+  }
+
+  .toggle-btn.active,
+  .tab-btn.active {
+    color: white;
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+  }
+
+  .layout {
     flex: 1;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: var(--desktop-cols);
+    gap: 0;
+  }
+
+  .pane {
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: var(--bg-secondary);
+  }
+
+  .explorer-pane,
+  .chat-pane {
+    border-right: 1px solid var(--border-subtle);
+  }
+
+  .preview-pane {
+    background: var(--bg-primary);
+    position: relative;
   }
 
   .section-header {
@@ -163,14 +396,8 @@
 
   .section-content {
     flex: 1;
+    min-height: 0;
     overflow: auto;
-  }
-
-  .preview-area {
-    background: var(--bg-primary);
-    position: relative;
-    overflow: hidden;
-    height: 100%;
   }
 
   .loading-preview {
@@ -196,8 +423,11 @@
   }
 
   .placeholder .icon {
-    font-size: 4rem;
-    opacity: 0.1;
+    font-size: 1rem;
+    opacity: 0.5;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    padding: 0.3rem 0.7rem;
   }
 
   h3 {
@@ -207,5 +437,31 @@
     letter-spacing: 0.1rem;
     text-transform: uppercase;
     color: var(--text-muted);
+  }
+
+  @media (max-width: 1100px) {
+    .workspace-toolbar {
+      flex-wrap: wrap;
+      height: auto;
+      padding: 8px 10px;
+      align-items: flex-start;
+    }
+
+    .mobile-tabs {
+      width: 100%;
+    }
+
+    .layout {
+      display: block;
+    }
+
+    .mobile-pane {
+      height: 100%;
+    }
+
+    .explorer-pane,
+    .chat-pane {
+      border-right: none;
+    }
   }
 </style>

--- a/webui/src/App.svelte
+++ b/webui/src/App.svelte
@@ -21,6 +21,10 @@
   const LAYOUT_STORAGE_KEY = 'webui.layout.v1';
   const NARROW_LAYOUT_QUERY = '(max-width: 1100px)';
 
+  function logLayoutStorageError(context: string, error: unknown): void {
+    console.warn(`[WebUI] ${context}`, error);
+  }
+
   function loadLayoutState(): void {
     try {
       const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
@@ -39,21 +43,25 @@
       if (parsed.mobilePanel === 'chat' || parsed.mobilePanel === 'explorer' || parsed.mobilePanel === 'preview') {
         mobilePanel = parsed.mobilePanel;
       }
-    } catch {
-      // Ignore malformed state.
+    } catch (error) {
+      logLayoutStorageError('Failed to restore layout state', error);
     }
   }
 
   function saveLayoutState(): void {
     if (!layoutInitialized) return;
-    localStorage.setItem(
-      LAYOUT_STORAGE_KEY,
-      JSON.stringify({
-        showExplorer,
-        showPreview,
-        mobilePanel,
-      })
-    );
+    try {
+      localStorage.setItem(
+        LAYOUT_STORAGE_KEY,
+        JSON.stringify({
+          showExplorer,
+          showPreview,
+          mobilePanel,
+        })
+      );
+    } catch (error) {
+      logLayoutStorageError('Failed to persist layout state', error);
+    }
   }
 
   function syncViewport(mql: MediaQueryList | MediaQueryListEvent): void {
@@ -157,13 +165,13 @@
         </div>
 
         {#if isNarrowScreen}
-          <div class="toolbar-group mobile-tabs" role="tablist" aria-label="Active panel">
+          <div class="toolbar-group mobile-tabs" role="group" aria-label="Active panel">
             {#if showExplorer}
               <button
                 class="tab-btn"
                 class:active={mobilePanel === 'explorer'}
-                role="tab"
-                aria-selected={mobilePanel === 'explorer'}
+                aria-pressed={mobilePanel === 'explorer'}
+                aria-label="Show files panel"
                 on:click={() => (mobilePanel = 'explorer')}
               >
                 Files
@@ -172,8 +180,8 @@
             <button
               class="tab-btn"
               class:active={mobilePanel === 'chat'}
-              role="tab"
-              aria-selected={mobilePanel === 'chat'}
+              aria-pressed={mobilePanel === 'chat'}
+              aria-label="Show chat panel"
               on:click={() => (mobilePanel = 'chat')}
             >
               Chat
@@ -182,8 +190,8 @@
               <button
                 class="tab-btn"
                 class:active={mobilePanel === 'preview'}
-                role="tab"
-                aria-selected={mobilePanel === 'preview'}
+                aria-pressed={mobilePanel === 'preview'}
+                aria-label="Show preview panel"
                 on:click={() => (mobilePanel = 'preview')}
               >
                 Preview


### PR DESCRIPTION
﻿## What/Why
- reworked WebUI layout so explorer and preview can be toggled independently, allowing chat to reclaim space when panels are hidden
- added responsive narrow-screen mode with panel tabs (Files/Chat/Preview)
- persisted panel state in localStorage so layout preferences survive reloads

## Implementation
- `webui/src/App.svelte`
  - added layout state (`showExplorer`, `showPreview`, `mobilePanel`, `isNarrowScreen`)
  - localStorage persistence key: `webui.layout.v1`
  - desktop multi-pane layout with dynamic columns
  - narrow-screen panel switching controls with accessible button semantics
- `README.md`
  - documented new responsive panel controls behavior
- planning/report artifacts:
  - `.agent/plans/11-webui-layout-responsiveness.md`
  - `.agent/reports/execution-reports/2026-02-03-11-webui-layout-responsiveness.md`

## How tested
- `npm --prefix webui run check`
- `npm run type-check`
- `npm run lint` (baseline warnings only)
- `npm test`
- `npm run build`

## Risks
- Tooling browser QA in this environment hit auth-context issues (`ERR_INVALID_AUTH_CREDENTIALS`), so runtime interaction was not validated via MCP Playwright in this pass.
- Drag-resize of pane widths is not included (future enhancement).

Fixes #11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responsive panel controls: independently collapse/expand Explorer and Preview.
  * Mobile-friendly tab navigation for Files, Chat, and Preview on narrow screens.
  * Layout preferences persist across sessions (per-browser).

* **Accessibility**
  * Improved keyboard and ARIA support for panel controls.

* **Documentation**
  * Added plan and execution report documenting the responsive UI implementation and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->