### PR TITLE
[#22] Add GitHub auth preflight diagnostics

### DIFF
--- a/.agent/plans/22-github-auth-preflight-diagnostics.md
+++ b/.agent/plans/22-github-auth-preflight-diagnostics.md
@@ -1,0 +1,67 @@
+# Issue #22 - GitHub Auth Preflight Diagnostics
+
+Issue: `#22`
+Repo: `imKXNNY/Remote-Agentic-Coding-System`
+Date: 2026-02-03
+
+## Goal
+Improve GitHub auth robustness and observability so misconfiguration is obvious and API behavior is deterministic when GitHub auth is unavailable.
+
+## Acceptance Criteria
+- [ ] Missing/invalid GitHub token results in clear, actionable error output.
+- [ ] `/api/github/issues` returns a deterministic error payload when auth is unavailable.
+- [ ] No token values are logged in plaintext.
+- [ ] Happy path behavior remains unchanged when token is valid.
+
+## Touch Points
+- `src/routes/github.ts`
+- `src/index.ts`
+- `src/handlers/command-handler.ts`
+- `src/utils/github-auth.ts` (new)
+- `src/utils/github-auth.test.ts` (new)
+- `README.md`
+
+## Implementation Slices
+
+### Slice 1 - Centralized auth diagnostics utility
+1. Add `src/utils/github-auth.ts` with:
+   - token resolution (`GITHUB_TOKEN` fallback to `GH_TOKEN`)
+   - token masking helper (never log secrets)
+   - preflight summary (presence, shape hints, source env var)
+   - standardized API error payload builder for auth failures
+2. Keep utility pure where possible for focused tests.
+
+### Slice 2 - Harden `/api/github/issues`
+1. In `src/routes/github.ts`, move from static module-level Octokit init to request-time guarded client creation.
+2. Return deterministic errors:
+   - `503` when token missing/malformed with actionable next steps
+   - `502` when upstream auth/permission errors occur
+3. Keep successful response shape unchanged.
+4. Ensure logs include context but never raw token.
+
+### Slice 3 - Startup and command-path diagnostics
+1. In `src/index.ts`, add startup preflight log for GitHub token readiness (sanitized).
+2. In `/clone` command (`src/handlers/command-handler.ts`), use same token resolution (`GITHUB_TOKEN ?? GH_TOKEN`) for consistency.
+
+### Slice 4 - Tests and docs
+1. Add targeted unit tests for `github-auth` utility.
+2. Add route-level regression tests for deterministic auth error behavior.
+3. Update README troubleshooting/docs with GitHub auth preflight behavior and expected scopes caveat.
+
+## Risks / Edge Cases
+- Private repo access may fail with insufficient scopes even if token exists.
+- GitHub API can return both auth and rate-limit errors; map only auth-class failures to deterministic auth messaging.
+- Keep route output backward-compatible for happy path.
+
+## Verification Commands
+- `npm run type-check`
+- `npm run lint`
+- `npm test -- src/utils/github-auth.test.ts src/routes/github.test.ts`
+- `npm test`
+- `npm --prefix webui run check`
+- `npm run build`
+
+## Execution Contract
+- **Issue:** `#22`
+- **Branch:** `fix/22-github-auth-preflight-diagnostics`
+- **Plan file path:** `.agent/plans/22-github-auth-preflight-diagnostics.md`

--- a/.agent/reports/execution-reports/2026-02-03-22-github-auth-preflight-diagnostics.md
+++ b/.agent/reports/execution-reports/2026-02-03-22-github-auth-preflight-diagnostics.md
@@ -1,0 +1,41 @@
+# Execution Report - Issue #22 GitHub Auth Preflight Diagnostics
+
+## Meta
+- Related Issue: #22
+- Branch: fix/22-github-auth-preflight-diagnostics
+- Plan file: `.agent/plans/22-github-auth-preflight-diagnostics.md`
+- Files modified:
+  - `README.md`
+  - `src/handlers/command-handler.ts`
+  - `src/index.ts`
+  - `src/routes/github.ts`
+- Files added:
+  - `src/utils/github-auth.ts`
+  - `src/utils/github-auth.test.ts`
+  - `src/routes/github.test.ts`
+  - `.agent/plans/22-github-auth-preflight-diagnostics.md`
+
+## What changed
+- Added centralized GitHub auth preflight utility with deterministic auth state and sanitized diagnostics.
+- Hardened `/api/github/issues` to return deterministic auth payloads:
+  - `503` + `GITHUB_AUTH_UNAVAILABLE` when token is missing/malformed.
+  - `502` + `GITHUB_AUTH_FAILED` when GitHub rejects credentials/scopes.
+- Added startup log preflight check in app bootstrap so auth readiness is visible immediately.
+- Standardized `/clone` token resolution to use `GITHUB_TOKEN ?? GH_TOKEN`.
+- Added targeted regression tests for utility and route behavior.
+- Updated README troubleshooting with auth preflight log checks and new API error codes.
+
+## Plan adherence
+- Matched all planned slices (utility, route hardening, startup/command consistency, tests/docs).
+- No functional divergence from plan; behavior changes are limited to auth failure handling paths.
+
+## Verification
+- `npm run type-check` -> PASS
+- `npm run lint` -> PASS (warnings only, pre-existing baseline)
+- `npm test -- src/utils/github-auth.test.ts src/routes/github.test.ts` -> PASS
+- `npm test` -> PASS (13/13 suites, 71/71 tests)
+- `npm --prefix webui run check` -> PASS
+- `npm run build` -> PASS
+
+## Follow-ups
+- Existing repo-wide ESLint warnings remain out of Issue #22 scope.

--- a/README.md
+++ b/README.md
@@ -854,9 +854,9 @@ docker compose logs app | grep "GitHub] Auth preflight"          # --profile ext
 docker compose logs app-with-db | grep "GitHub] Auth preflight"  # --profile with-db
 ```
 
-If auth is unavailable, `GET /api/github/issues` now returns a deterministic `503` payload with code:
-- `GITHUB_AUTH_UNAVAILABLE` (missing/malformed token)
-- `GITHUB_AUTH_FAILED` (upstream GitHub rejected token/scopes)
+`GET /api/github/issues` error codes:
+- `503` + `GITHUB_AUTH_UNAVAILABLE` (missing/malformed token)
+- `502` + `GITHUB_AUTH_FAILED` (GitHub rejected credentials/scopes)
 
 **Test token validity:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -847,6 +847,17 @@ cat .env | grep GH_TOKEN
 # Should have both GH_TOKEN and GITHUB_TOKEN set
 ```
 
+**Check runtime preflight diagnostics:**
+```bash
+# Use the service name matching your profile
+docker compose logs app | grep "GitHub] Auth preflight"          # --profile external-db
+docker compose logs app-with-db | grep "GitHub] Auth preflight"  # --profile with-db
+```
+
+If auth is unavailable, `GET /api/github/issues` now returns a deterministic `503` payload with code:
+- `GITHUB_AUTH_UNAVAILABLE` (missing/malformed token)
+- `GITHUB_AUTH_FAILED` (upstream GitHub rejected token/scopes)
+
 **Test token validity:**
 ```bash
 # Test GitHub API access

--- a/src/handlers/command-handler.ts
+++ b/src/handlers/command-handler.ts
@@ -413,7 +413,7 @@ Session:
 
         // Build clone command with authentication if GitHub token is available
         let cloneCommand = `git clone ${repoUrl} ${targetPath}`;
-        const ghToken = process.env.GH_TOKEN;
+        const ghToken = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
 
         if (ghToken && repoUrl.includes('github.com')) {
           // Inject token into GitHub URL for private repo access

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { startMcpServer } from './mcp-server';
 import uploadRouter from './routes/upload';
 import githubRouter from './routes/github';
 import { asyncHandler } from './utils/async-handler';
+import { getGitHubAuthPreflight } from './utils/github-auth';
 
 // Extended WebSocket for heartbeat
 interface ExtWebSocket extends WebSocket {
@@ -77,6 +78,17 @@ async function main(): Promise<void> {
   }
   if (!hasCodexCredentials) {
     console.warn('[App] Codex credentials not found. Codex assistant will be unavailable.');
+  }
+
+  const githubAuthPreflight = getGitHubAuthPreflight();
+  if (githubAuthPreflight.ready) {
+    console.log(
+      `[GitHub] Auth preflight OK (${githubAuthPreflight.source}, length: ${String(githubAuthPreflight.tokenLength)})`
+    );
+  } else {
+    console.warn(
+      `[GitHub] Auth preflight not ready: ${githubAuthPreflight.reason ?? 'missing token'} (set GH_TOKEN or GITHUB_TOKEN)`
+    );
   }
 
   // Test database connection

--- a/src/routes/github.test.ts
+++ b/src/routes/github.test.ts
@@ -1,0 +1,119 @@
+import type { Request, Response } from 'express';
+import { Octokit } from '@octokit/rest';
+import { getGithubIssuesHandler } from './github';
+
+jest.mock('@octokit/rest', () => ({
+  Octokit: jest.fn(),
+}));
+
+type MockResponse = Response & {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+function createResponse(): MockResponse {
+  const res = {} as MockResponse;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function createRequest(owner = 'imKXNNY', repo = 'Remote-Agentic-Coding-System'): Request {
+  return {
+    query: { owner, repo },
+  } as unknown as Request;
+}
+
+describe('github route auth diagnostics', () => {
+  const originalEnv = process.env;
+  let listForRepo: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    listForRepo = jest.fn();
+    (Octokit as unknown as jest.Mock).mockImplementation(() => ({
+      rest: {
+        issues: {
+          listForRepo,
+        },
+      },
+    }));
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('returns 503 with deterministic payload when token is missing', async () => {
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    const req = createRequest();
+    const res = createResponse();
+
+    await getGithubIssuesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'GITHUB_AUTH_UNAVAILABLE',
+      })
+    );
+    expect(Octokit).not.toHaveBeenCalled();
+  });
+
+  test('returns issues on happy path and filters pull requests', async () => {
+    process.env.GH_TOKEN = 'ghp_abcdefghijklmnopqrstuvwxyz1234567890';
+    listForRepo.mockResolvedValue({
+      data: [
+        {
+          number: 1,
+          title: 'Issue 1',
+          html_url: 'https://github.com/example/repo/issues/1',
+          state: 'open',
+          user: { login: 'alice' },
+          labels: [{ name: 'bug' }],
+        },
+        {
+          number: 2,
+          title: 'PR 2',
+          html_url: 'https://github.com/example/repo/pull/2',
+          state: 'open',
+          user: { login: 'bob' },
+          labels: [],
+          pull_request: { url: 'https://api.github.com/repos/example/repo/pulls/2' },
+        },
+      ],
+    });
+
+    const req = createRequest();
+    const res = createResponse();
+
+    await getGithubIssuesHandler(req, res);
+
+    expect(res.json).toHaveBeenCalledWith([
+      expect.objectContaining({
+        number: 1,
+        title: 'Issue 1',
+        is_pull_request: false,
+      }),
+    ]);
+  });
+
+  test('returns 502 when GitHub rejects credentials', async () => {
+    process.env.GITHUB_TOKEN = 'ghp_abcdefghijklmnopqrstuvwxyz1234567890';
+    listForRepo.mockRejectedValue({ status: 401, message: 'Bad credentials' });
+
+    const req = createRequest();
+    const res = createResponse();
+
+    await getGithubIssuesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'GITHUB_AUTH_FAILED',
+      })
+    );
+  });
+});

--- a/src/routes/github.test.ts
+++ b/src/routes/github.test.ts
@@ -62,6 +62,19 @@ describe('github route auth diagnostics', () => {
     expect(Octokit).not.toHaveBeenCalled();
   });
 
+  test('returns 400 when owner/repo query params are not strings', async () => {
+    process.env.GH_TOKEN = 'ghp_abcdefghijklmnopqrstuvwxyz1234567890';
+    const req = {
+      query: { owner: ['imKXNNY'], repo: 'Remote-Agentic-Coding-System' },
+    } as unknown as Request;
+    const res = createResponse();
+
+    await getGithubIssuesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(Octokit).not.toHaveBeenCalled();
+  });
+
   test('returns issues on happy path and filters pull requests', async () => {
     process.env.GH_TOKEN = 'ghp_abcdefghijklmnopqrstuvwxyz1234567890';
     listForRepo.mockResolvedValue({

--- a/src/routes/github.ts
+++ b/src/routes/github.ts
@@ -1,27 +1,45 @@
 import { Router } from 'express';
 import { Octokit } from '@octokit/rest';
+import type { Request, Response } from 'express';
 import { asyncHandler } from '../utils/async-handler';
+import {
+  createAuthFailedPayload,
+  createAuthUnavailablePayload,
+  getGitHubApiErrorStatus,
+  getGitHubAuthPreflight,
+} from '../utils/github-auth';
 
 const router = Router();
-
-// Initialize Octokit with the server's token
-// This allows the WebUI to browse issues without forcing every user to provide a token
-const octokit = new Octokit({ 
-  auth: process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN 
-});
 
 /**
  * GET /api/github/issues
  * Fetch open issues for a repository
  * Query params: owner, repo
  */
-router.get('/github/issues', asyncHandler(async (req, res) => {
+export async function getGithubIssuesHandler(req: Request, res: Response): Promise<void> {
   const owner = req.query.owner as string;
   const repo = req.query.repo as string;
 
   if (!owner || !repo) {
-    return res.status(400).json({ error: 'Missing owner or repo query parameters' });
+    res.status(400).json({ error: 'Missing owner or repo query parameters' });
+    return;
   }
+
+  const preflight = getGitHubAuthPreflight();
+  if (!preflight.ready || !preflight.token) {
+    console.warn('[API] GitHub auth unavailable for /api/github/issues', {
+      reason: preflight.reason,
+      source: preflight.source,
+      hasGITHUB_TOKEN: preflight.hasGITHUB_TOKEN,
+      hasGH_TOKEN: preflight.hasGH_TOKEN,
+    });
+    res.status(503).json(createAuthUnavailablePayload(preflight));
+    return;
+  }
+
+  const octokit = new Octokit({
+    auth: preflight.token,
+  });
 
   try {
     const { data } = await octokit.rest.issues.listForRepo({
@@ -51,12 +69,26 @@ router.get('/github/issues', asyncHandler(async (req, res) => {
     // For "Connect to Issue" context, standard issues are usually what we want (triage etc).
     const onlyIssues = issues.filter(i => !i.is_pull_request);
 
-    return res.json(onlyIssues);
+    res.json(onlyIssues);
+    return;
   } catch (error) {
+    const status = getGitHubApiErrorStatus(error);
+    if (status === 401 || status === 403) {
+      console.warn('[API] GitHub auth failed for /api/github/issues', {
+        status,
+        source: preflight.source,
+      });
+      res.status(502).json(createAuthFailedPayload(preflight));
+      return;
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     console.error('[API] Failed to fetch GitHub issues:', message);
-    return res.status(500).json({ error: 'Failed to fetch issues from GitHub' });
+    res.status(500).json({ error: 'Failed to fetch issues from GitHub', code: 'GITHUB_API_ERROR' });
+    return;
   }
-}));
+}
+
+router.get('/github/issues', asyncHandler(getGithubIssuesHandler));
 
 export default router;

--- a/src/routes/github.ts
+++ b/src/routes/github.ts
@@ -17,8 +17,8 @@ const router = Router();
  * Query params: owner, repo
  */
 export async function getGithubIssuesHandler(req: Request, res: Response): Promise<void> {
-  const owner = req.query.owner as string;
-  const repo = req.query.repo as string;
+  const owner = typeof req.query.owner === 'string' ? req.query.owner : undefined;
+  const repo = typeof req.query.repo === 'string' ? req.query.repo : undefined;
 
   if (!owner || !repo) {
     res.status(400).json({ error: 'Missing owner or repo query parameters' });

--- a/src/utils/github-auth.test.ts
+++ b/src/utils/github-auth.test.ts
@@ -1,0 +1,64 @@
+import {
+  createAuthFailedPayload,
+  createAuthUnavailablePayload,
+  getGitHubApiErrorStatus,
+  getGitHubAuthPreflight,
+  maskToken,
+} from './github-auth';
+
+describe('github-auth utility', () => {
+  test('returns missing preflight when no token env is present', () => {
+    const preflight = getGitHubAuthPreflight({});
+
+    expect(preflight.ready).toBe(false);
+    expect(preflight.tokenState).toBe('missing');
+    expect(preflight.source).toBe('none');
+  });
+
+  test('prefers GITHUB_TOKEN over GH_TOKEN when both are set', () => {
+    const preflight = getGitHubAuthPreflight({
+      GITHUB_TOKEN: 'ghp_abcdefghijklmnopqrstuvwxyz1234567890',
+      GH_TOKEN: 'ghp_override_should_not_be_used_1234567890',
+    });
+
+    expect(preflight.ready).toBe(true);
+    expect(preflight.source).toBe('GITHUB_TOKEN');
+    expect(preflight.token).toBe('ghp_abcdefghijklmnopqrstuvwxyz1234567890');
+  });
+
+  test('flags short token as malformed', () => {
+    const preflight = getGitHubAuthPreflight({
+      GH_TOKEN: 'ghp_short',
+    });
+
+    expect(preflight.ready).toBe(false);
+    expect(preflight.tokenState).toBe('malformed');
+  });
+
+  test('masks token values', () => {
+    expect(maskToken(null)).toBe('<missing>');
+    expect(maskToken('ghp_abcdefghijklmnopqrstuvwxyz')).toBe('ghp_...wxyz');
+  });
+
+  test('builds deterministic auth error payloads', () => {
+    const preflight = getGitHubAuthPreflight({});
+    const unavailable = createAuthUnavailablePayload(preflight);
+    const failed = createAuthFailedPayload({
+      ...preflight,
+      source: 'GH_TOKEN',
+      hasGH_TOKEN: true,
+      reason: 'scope missing',
+    });
+
+    expect(unavailable.code).toBe('GITHUB_AUTH_UNAVAILABLE');
+    expect(failed.code).toBe('GITHUB_AUTH_FAILED');
+    expect(unavailable.details.hint).toContain('GH_TOKEN');
+    expect(failed.details.reason).toContain('rejected credentials');
+  });
+
+  test('extracts status from octokit-like errors', () => {
+    expect(getGitHubApiErrorStatus({ status: 401 })).toBe(401);
+    expect(getGitHubApiErrorStatus({ status: '401' })).toBeNull();
+    expect(getGitHubApiErrorStatus(new Error('boom'))).toBeNull();
+  });
+});

--- a/src/utils/github-auth.test.ts
+++ b/src/utils/github-auth.test.ts
@@ -35,8 +35,18 @@ describe('github-auth utility', () => {
     expect(preflight.tokenState).toBe('malformed');
   });
 
+  test('accepts token at minimum length boundary', () => {
+    const preflight = getGitHubAuthPreflight({
+      GH_TOKEN: 'ghp_1234567890123456',
+    });
+
+    expect(preflight.ready).toBe(true);
+    expect(preflight.tokenState).toBe('present');
+  });
+
   test('masks token values', () => {
     expect(maskToken(null)).toBe('<missing>');
+    expect(maskToken('ghp_1234')).toBe('********');
     expect(maskToken('ghp_abcdefghijklmnopqrstuvwxyz')).toBe('ghp_...wxyz');
   });
 

--- a/src/utils/github-auth.ts
+++ b/src/utils/github-auth.ts
@@ -1,0 +1,122 @@
+export type GitHubTokenSource = 'GITHUB_TOKEN' | 'GH_TOKEN' | 'none';
+export type GitHubTokenState = 'present' | 'missing' | 'malformed';
+
+export interface GitHubAuthPreflight {
+  ready: boolean;
+  source: GitHubTokenSource;
+  token: string | null;
+  tokenState: GitHubTokenState;
+  tokenLength: number;
+  hasGITHUB_TOKEN: boolean;
+  hasGH_TOKEN: boolean;
+  reason?: string;
+}
+
+export interface GitHubAuthErrorPayload {
+  error: string;
+  code: 'GITHUB_AUTH_UNAVAILABLE' | 'GITHUB_AUTH_FAILED';
+  details: {
+    reason: string;
+    source: GitHubTokenSource;
+    hasGITHUB_TOKEN: boolean;
+    hasGH_TOKEN: boolean;
+    hint: string;
+  };
+}
+
+const MIN_TOKEN_LENGTH = 20;
+
+function normalizeToken(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isMalformedToken(token: string): boolean {
+  return token.length < MIN_TOKEN_LENGTH;
+}
+
+export function maskToken(token: string | null): string {
+  if (!token) return '<missing>';
+  if (token.length <= 8) return '********';
+  return `${token.slice(0, 4)}...${token.slice(-4)}`;
+}
+
+export function getGitHubAuthPreflight(env: NodeJS.ProcessEnv = process.env): GitHubAuthPreflight {
+  const githubToken = normalizeToken(env.GITHUB_TOKEN);
+  const ghToken = normalizeToken(env.GH_TOKEN);
+  const token = githubToken ?? ghToken;
+  const source: GitHubTokenSource = githubToken ? 'GITHUB_TOKEN' : ghToken ? 'GH_TOKEN' : 'none';
+
+  if (!token) {
+    return {
+      ready: false,
+      source,
+      token: null,
+      tokenState: 'missing',
+      tokenLength: 0,
+      hasGITHUB_TOKEN: Boolean(githubToken),
+      hasGH_TOKEN: Boolean(ghToken),
+      reason: 'Missing GitHub token env vars',
+    };
+  }
+
+  if (isMalformedToken(token)) {
+    return {
+      ready: false,
+      source,
+      token,
+      tokenState: 'malformed',
+      tokenLength: token.length,
+      hasGITHUB_TOKEN: Boolean(githubToken),
+      hasGH_TOKEN: Boolean(ghToken),
+      reason: 'Token appears malformed (too short)',
+    };
+  }
+
+  return {
+    ready: true,
+    source,
+    token,
+    tokenState: 'present',
+    tokenLength: token.length,
+    hasGITHUB_TOKEN: Boolean(githubToken),
+    hasGH_TOKEN: Boolean(ghToken),
+  };
+}
+
+export function createAuthUnavailablePayload(preflight: GitHubAuthPreflight): GitHubAuthErrorPayload {
+  return {
+    error: 'GitHub authentication is not configured',
+    code: 'GITHUB_AUTH_UNAVAILABLE',
+    details: {
+      reason: preflight.reason ?? 'Missing token',
+      source: preflight.source,
+      hasGITHUB_TOKEN: preflight.hasGITHUB_TOKEN,
+      hasGH_TOKEN: preflight.hasGH_TOKEN,
+      hint: 'Set GH_TOKEN or GITHUB_TOKEN in .env and restart the service.',
+    },
+  };
+}
+
+export function createAuthFailedPayload(preflight: GitHubAuthPreflight): GitHubAuthErrorPayload {
+  return {
+    error: 'GitHub authentication failed for this request',
+    code: 'GITHUB_AUTH_FAILED',
+    details: {
+      reason: 'GitHub API rejected credentials or token scopes for this operation',
+      source: preflight.source,
+      hasGITHUB_TOKEN: preflight.hasGITHUB_TOKEN,
+      hasGH_TOKEN: preflight.hasGH_TOKEN,
+      hint: 'Verify token validity/scopes (repo, read:org if org metadata is required), then restart the service.',
+    },
+  };
+}
+
+export function getGitHubApiErrorStatus(error: unknown): number | null {
+  if (typeof error !== 'object' || error === null || !('status' in error)) {
+    return null;
+  }
+  const status = (error as { status?: unknown }).status;
+  return typeof status === 'number' ? status : null;
+}


### PR DESCRIPTION
## What
- add centralized GitHub auth preflight utility (`src/utils/github-auth.ts`) for deterministic token resolution and sanitized diagnostics
- harden `/api/github/issues` to return deterministic auth failures:
  - `503` + `GITHUB_AUTH_UNAVAILABLE` when token is missing/malformed
  - `502` + `GITHUB_AUTH_FAILED` when GitHub rejects credentials/scopes
- log startup GitHub auth readiness in `src/index.ts`
- align `/clone` auth token lookup to `GITHUB_TOKEN ?? GH_TOKEN`
- add regression tests for auth utility + github route behavior
- document new diagnostics behavior in README troubleshooting

## Why
Issue #9 was closed as non-repro after environment normalization, but it exposed a workflow risk: auth/config problems were not consistently surfaced with actionable diagnostics. This change makes auth state explicit and API failures deterministic.

## How tested
- `npm run type-check`
- `npm run lint` (warnings only, no errors)
- `npm test -- src/utils/github-auth.test.ts src/routes/github.test.ts`
- `npm test`
- `npm --prefix webui run check`
- `npm run build`

## Risks
- API consumers of `/api/github/issues` may now receive structured error codes (`GITHUB_AUTH_UNAVAILABLE`, `GITHUB_AUTH_FAILED`) for auth failures instead of a generic `500`; this is intentional and documented.

Fixes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized GitHub auth preflight check with sanitized startup diagnostics and token-source preference (GITHUB_TOKEN → GH_TOKEN).

* **Behavior**
  * Hardened GitHub issues endpoint with deterministic auth errors: 503 for missing/malformed token, 502 for rejected credentials; successful responses unchanged.

* **Documentation**
  * README updated with preflight troubleshooting, error codes, and token validation steps.

* **Tests**
  * Added unit and regression tests covering preflight logic and deterministic auth error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->