### PR TITLE
docs: evaluate get-shit-done and decide adoption path

### DIFF
--- a/.agent/plans/18-get-shit-done-evaluation.md
+++ b/.agent/plans/18-get-shit-done-evaluation.md
@@ -1,0 +1,38 @@
+# Issue #18 - Get-shit-done Evaluation and Adoption Decision
+
+Issue: `#18`
+Repo: `imKXNNY/Remote-Agentic-Coding-System`
+Date: 2026-02-03
+
+## Goal
+Research Get-shit-done, evaluate compatibility with this repository (especially Codex-oriented workflows), and produce a clear adoption recommendation.
+
+## Acceptance Criteria
+- [ ] A clear recommendation exists with tradeoffs and migration effort.
+- [ ] Any proposed implementation path has explicit phases and risks.
+- [ ] README/docs link to final recommendation artifact.
+
+## Touch Points
+- `docs/Get-Shit-Done/README.md` (new index)
+- `docs/Get-Shit-Done/reference/get-shit-done-overview.md` (new)
+- `docs/Get-Shit-Done/research/codex-compatibility.md` (new)
+- `docs/Get-Shit-Done/analysis/adoption-decision.md` (new)
+- `README.md` (docs discoverability)
+
+## Execution Slices
+1. Collect source facts from upstream repository (scope, runtime support, workflow model).
+2. Write reference and Codex-compatibility research docs.
+3. Write adoption decision with options and phased recommendation.
+4. Update README to link docs.
+
+## Verification Commands
+- `npm run type-check`
+- `npm run lint`
+- `npm test`
+- `npm --prefix webui run check`
+- `npm run build`
+
+## Execution Contract
+- **Issue:** `#18`
+- **Branch:** `feature/18-get-shit-done-evaluation`
+- **Plan file path:** `.agent/plans/18-get-shit-done-evaluation.md`

--- a/.agent/reports/execution-reports/2026-02-03-18-get-shit-done-evaluation.md
+++ b/.agent/reports/execution-reports/2026-02-03-18-get-shit-done-evaluation.md
@@ -1,0 +1,39 @@
+# Execution Report - Issue #18 Get-shit-done Evaluation
+
+## Meta
+- Related Issue: #18
+- Branch: feature/18-get-shit-done-evaluation
+- Plan file: `.agent/plans/18-get-shit-done-evaluation.md`
+- Files modified:
+  - `README.md`
+- Files added:
+  - `docs/Get-Shit-Done/README.md`
+  - `docs/Get-Shit-Done/reference/get-shit-done-overview.md`
+  - `docs/Get-Shit-Done/research/codex-compatibility.md`
+  - `docs/Get-Shit-Done/analysis/adoption-decision.md`
+  - `.agent/plans/18-get-shit-done-evaluation.md`
+
+## What changed
+- Added a dedicated Get-shit-done documentation hub with reference, research, and analysis artifacts.
+- Captured upstream project snapshot and workflow/runtime facts.
+- Completed Codex compatibility research and identified indirect/partial compatibility.
+- Added explicit adoption decision with options, tradeoffs, migration effort, phases, and risks.
+- Chosen recommendation: **partial adaptation** (pattern-level adoption, not direct runtime replacement).
+- Created follow-up implementation issue `#28` for pilot adoption.
+- Updated README architecture "Further reading" to link Get-shit-done docs.
+
+## Plan adherence
+- All issue #18 acceptance criteria satisfied:
+  - clear recommendation + tradeoffs/migration effort
+  - explicit phased implementation path + risks
+  - docs link added to README for discoverability
+
+## Verification
+- `npm run type-check` -> PASS
+- `npm run lint` -> PASS (warnings only, existing baseline)
+- `npm test` -> PASS (13/13 suites, 73/73 tests)
+- `npm --prefix webui run check` -> PASS
+- `npm run build` -> PASS
+
+## Follow-ups
+- `#28` tracks pilot implementation of selective GSD pattern adoption.

--- a/README.md
+++ b/README.md
@@ -715,6 +715,7 @@ Commands are version-controlled with your codebase, not stored in the database.
 Further reading:
 - Core architecture guide: `docs/architecture.md`
 - OpenClaw research and integration decision: `docs/OpenClaw/README.md`
+- Get-shit-done evaluation and adoption decision: `docs/Get-Shit-Done/README.md`
 
 ### System Overview
 

--- a/docs/Get-Shit-Done/README.md
+++ b/docs/Get-Shit-Done/README.md
@@ -5,6 +5,7 @@ This folder tracks reference material, compatibility research, and adoption deci
 ## Structure
 - `reference/get-shit-done-overview.md` - upstream project snapshot and key capabilities.
 - `research/codex-compatibility.md` - compatibility analysis for Codex-oriented workflows.
+- `research/claude-gemini-overlap-divergence.md` - overlap and divergence analysis vs Claude/Gemini-oriented usage.
 - `analysis/adoption-decision.md` - recommendation, tradeoffs, migration effort, and phased path.
 
 ## Current Recommendation

--- a/docs/Get-Shit-Done/README.md
+++ b/docs/Get-Shit-Done/README.md
@@ -1,0 +1,11 @@
+# Get-shit-done Research Hub
+
+This folder tracks reference material, compatibility research, and adoption decisions for `get-shit-done` in `Remote-Agentic-Coding-System`.
+
+## Structure
+- `reference/get-shit-done-overview.md` - upstream project snapshot and key capabilities.
+- `research/codex-compatibility.md` - compatibility analysis for Codex-oriented workflows.
+- `analysis/adoption-decision.md` - recommendation, tradeoffs, migration effort, and phased path.
+
+## Current Recommendation
+See `analysis/adoption-decision.md`.

--- a/docs/Get-Shit-Done/analysis/adoption-decision.md
+++ b/docs/Get-Shit-Done/analysis/adoption-decision.md
@@ -1,0 +1,79 @@
+# Get-shit-done Adoption Decision (Issue #18)
+
+Date: 2026-02-03
+Status: Decision complete
+
+## Objective
+Decide whether Get-shit-done should be adopted in `Remote-Agentic-Coding-System`, and at what depth.
+
+## Options Evaluated
+
+### A) Adopt directly
+Use GSD command system and workflow model as-is.
+
+Pros:
+- Fast reuse of mature, battle-tested process patterns.
+
+Cons:
+- Runtime support is primarily documented for Claude/OpenCode/Gemini, not Codex-first usage.
+- High overlap/conflict risk with current `.agent/` workflow conventions.
+- Higher migration complexity and operator confusion.
+
+### B) Partial adaptation (selected)
+Adopt selected concepts and patterns, but keep this repo's existing workflow contracts and tooling.
+
+Pros:
+- Preserves current issue-first and `.agent/` artifacts.
+- Enables incremental improvements with low disruption.
+- Avoids runtime coupling risk.
+
+Cons:
+- Requires curation/mapping effort.
+- Some duplication with upstream concepts remains.
+
+### C) Inspiration-only
+Use GSD only as reference; no explicit integration backlog.
+
+Pros:
+- No migration cost.
+
+Cons:
+- Leaves potential process quality gains unrealized.
+
+## Decision
+Choose **B) Partial adaptation**.
+
+## Why
+- Best fit for current architecture and operating model.
+- Lowest implementation risk while still extracting value.
+- Clear path to improve planning/execution quality without replacing stable workflows.
+
+## Migration Effort Estimate
+- Phase 1 (mapping/design): low
+- Phase 2 (pilot workflow adjustments): medium
+- Phase 3 (broader rollout + documentation): medium
+
+## Proposed Phases
+1. Pattern mapping:
+   - map transferable GSD concepts to `.agent/workflows/*`
+   - identify non-transferable runtime-specific assumptions
+2. Pilot:
+   - apply selected changes to one issue workflow family
+   - measure quality/rework impact
+3. Rollout:
+   - standardize successful changes across default workflow set
+   - update documentation and contributor guidance
+
+## Risks
+- Overfitting to external workflow semantics that conflict with repo norms.
+- Process churn without measurable gain.
+- Ambiguity if both original and adapted terminology coexist.
+
+Mitigations:
+- keep canonical source of truth in `.agent/rules/00-core.md`
+- apply changes in small, measurable increments
+- maintain compatibility with current issue/plan/report contracts
+
+## Follow-up
+Implementation tracking issue: **#28 - Pilot selective GSD pattern adoption into default workflows**
+(https://github.com/imKXNNY/Remote-Agentic-Coding-System/issues/28)

--- a/docs/Get-Shit-Done/analysis/adoption-decision.md
+++ b/docs/Get-Shit-Done/analysis/adoption-decision.md
@@ -47,6 +47,8 @@ Choose **B) Partial adaptation**.
 - Best fit for current architecture and operating model.
 - Lowest implementation risk while still extracting value.
 - Clear path to improve planning/execution quality without replacing stable workflows.
+- Supported by research showing strong process overlap but runtime divergence for Claude/Gemini-oriented usage:
+  - `docs/Get-Shit-Done/research/claude-gemini-overlap-divergence.md`
 
 ## Migration Effort Estimate
 - Phase 1 (mapping/design): low

--- a/docs/Get-Shit-Done/reference/get-shit-done-overview.md
+++ b/docs/Get-Shit-Done/reference/get-shit-done-overview.md
@@ -1,0 +1,30 @@
+# Get-shit-done Overview (Reference)
+
+Date captured: 2026-02-03
+Source: `https://github.com/glittercowboy/get-shit-done`
+
+## Project Summary
+Get-shit-done (GSD) describes itself as a lightweight, spec-driven development system focused on reducing context degradation in long AI-assisted coding sessions.
+
+## Upstream Signals
+- Repository: `glittercowboy/get-shit-done`
+- License: MIT
+- Popularity snapshot (capture date): ~11k stars, ~1k forks
+- Runtime focus in installer/docs: Claude Code, OpenCode, Gemini CLI
+
+## Workflow Model
+From the upstream README and workflow files, GSD centers around command-driven phases:
+- project bootstrap (`/gsd:new-project`)
+- phase discussion/planning/execution/verification
+- milestone audit and completion
+- ongoing progress/state continuity
+
+## Artifact Model
+GSD uses structured planning artifacts (project/requirements/roadmap/state/research) and command workflows as first-class operational objects. This aligns conceptually with this repo's `.agent/` plans + reports pattern, although naming and execution mechanics differ.
+
+## Runtime Support Facts (as of capture)
+- Explicit installer/runtime flags include: `--claude`, `--opencode`, `--gemini`, `--all`.
+- No explicit Codex runtime flag was observed in upstream installer help/options.
+
+## Notes
+This file is descriptive, not prescriptive. See analysis docs for adoption recommendations.

--- a/docs/Get-Shit-Done/research/claude-gemini-overlap-divergence.md
+++ b/docs/Get-Shit-Done/research/claude-gemini-overlap-divergence.md
@@ -1,0 +1,37 @@
+# Claude/Gemini Overlap and Divergence
+
+Date: 2026-02-03
+Scope: compare workflow behavior and assumptions between Claude/Gemini-centric GSD usage and this repository's Codex-centered operating model.
+
+## Overlap
+
+1) Spec-first execution model
+- All three models benefit from explicit phases: prime, plan, execute, review, validate.
+- Artifact continuity (plans/reports/checklists) improves quality independent of model provider.
+
+2) Prompt and context discipline
+- Structured prompts and bounded context reduce drift and rework.
+- Clear contracts for outputs (plan format, validation gates, review criteria) transfer well across runtimes.
+
+3) Verification-first completion
+- Gated validation before merge is a shared requirement.
+- Human-readable traceability (issue -> plan -> execution report -> PR) is universally useful.
+
+## Divergence
+
+1) Runtime/tooling assumptions
+- GSD is documented primarily for Claude Code/OpenCode/Gemini CLI workflows.
+- This repo uses Codex CLI conventions, `.agent/workflows/*`, and existing command/report contracts.
+
+2) Command surface and operator UX
+- GSD command namespaces and conventions may differ from current repo commands.
+- Direct adoption can create cognitive load if two workflow vocabularies coexist.
+
+3) Integration boundaries
+- This repo has established issue-first contracts tied to branch/plan/report paths.
+- Replacing those primitives would increase migration and onboarding risk.
+
+## Implication for this repository
+
+The strongest compatibility is at the pattern level (phase discipline, context contracts, validation rigor), not at direct runtime replacement. This supports a partial adaptation strategy: keep current Codex-first workflow interfaces while importing proven GSD process patterns where they improve quality.
+

--- a/docs/Get-Shit-Done/research/codex-compatibility.md
+++ b/docs/Get-Shit-Done/research/codex-compatibility.md
@@ -1,0 +1,38 @@
+# Codex Compatibility Research
+
+Date: 2026-02-03
+Scope: evaluate whether GSD can be used directly with this repository's Codex-centered workflows.
+
+## Findings
+
+### 1) Direct runtime support is not explicit for Codex
+Upstream installer/runtime options and docs explicitly target:
+- Claude Code
+- OpenCode
+- Gemini CLI
+
+No first-class Codex runtime option is currently documented in the same way.
+
+### 2) Conceptual workflow fit is high
+Despite runtime-targeting differences, GSD's approach overlaps with this repo's working model:
+- issue-driven planning and execution
+- explicit phase sequencing
+- artifact-backed continuity
+- verification gates before completion
+
+This means many ideas are transferable even without direct installer compatibility.
+
+### 3) Integration friction points
+Potential friction for direct adoption:
+- command namespace and UX (`/gsd:*` model) vs current `.agent/workflows/*` approach
+- runtime-specific assumptions tuned for Claude/OpenCode/Gemini
+- potential duplication/conflict with existing issue-first process and report contracts
+
+### 4) Low-risk compatibility path
+The safest approach is pattern-level adoption first:
+- borrow proven concepts (phase discipline, verification patterns, planning structure)
+- map into current `.agent/` command/workflow model
+- avoid replacing established orchestration primitives prematurely
+
+## Conclusion
+Codex compatibility appears **indirect/partial** rather than plug-and-play. GSD is best treated as a high-quality reference system whose concepts can be selectively integrated into this repository's existing Codex-oriented architecture.


### PR DESCRIPTION
## Summary\n- add Get-shit-done docs hub with reference, compatibility research, and decision analysis\n- document a pragmatic adoption decision (partial pattern adoption) with phased rollout\n- add execution artifacts (plan + execution report) for issue-traceability\n\n## Validation\n- npm run type-check\n- npm run lint\n- npm test\n- npm --prefix webui run check\n- npm run build\n\nFixes #18\nFollow-up: #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a Get‑Shit‑Done research hub with overview, compatibility analysis (Codex/Claude/Gemini), and an adoption decision recommending partial adaptation with phases, risks, and follow-ups.
  - Published an execution report summarizing findings, verification results, and next steps.
  - Linked the new materials from the README (Further reading and Architecture).

- Chores
  - Added a planning document to guide evaluation and tracking.
  - Recorded verification status for type-check, lint, tests, UI checks, and build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->