### PR TITLE
[#31] feat: webhook policy engine and approval gates

### DIFF
--- a/.agent/plans/31-webhook-policy-engine-and-approval-gates.md
+++ b/.agent/plans/31-webhook-policy-engine-and-approval-gates.md
@@ -1,0 +1,93 @@
+# Issue #31 - Webhook Policy Engine and Approval Gates
+
+Issue: `#31`
+Repo: `imKXNNY/Remote-Agentic-Coding-System`
+Date: 2026-02-04
+
+## Goal
+Implement policy evaluation and approval gating for webhook-triggered automation so autonomous actions remain safe, auditable, and explicitly controlled.
+
+## Acceptance Criteria
+- [ ] High-risk operations require explicit human approval.
+- [ ] Protected path writes are blocked without override.
+- [ ] Policy outcomes are explicit and auditable.
+
+## Touch Points
+- `src/utils/webhook-policy.ts` (new policy model + evaluator)
+- `src/db/webhook-control-plane.ts` (persist policy/risk decisions and approval transitions)
+- `migrations/010_webhook_policy_gates.sql` (add policy/risk/approval columns)
+- `src/db/schema.ts` (runtime compatibility for new columns)
+- `src/adapters/github.ts` (evaluate policy during intake, add approve-run handling)
+- `src/adapters/github.test.ts` (policy + approval regression tests)
+- `src/utils/webhook-policy.test.ts` (new evaluator tests)
+- `src/routes/github.ts` + `src/routes/github.test.ts` (optional run filtering for audit visibility)
+
+## Execution Slices
+
+### Slice 1 - Policy model and evaluator
+1. Add a dedicated webhook policy utility module with:
+   - repository allowlist resolver
+   - branch allowlist matcher
+   - command allowlist matcher
+   - protected path matcher
+   - risk tier classifier (`low`/`medium`/`high`)
+2. Expose a single evaluation function returning deterministic decision:
+   - `allow`
+   - `requires_approval`
+   - `blocked`
+3. Add unit tests for all decision branches and env-config defaults.
+
+### Slice 2 - Persistence and approval state transitions
+1. Add migration and schema compatibility fields on automation runs:
+   - `risk_tier`
+   - `policy_decision`
+   - `policy_reason`
+   - `approved_by`
+   - `approved_at`
+2. Extend webhook DB intake API to persist policy/risk metadata and support `requires_approval` run status.
+3. Add DB helper to approve a pending run by id (`requires_approval` -> `accepted`) with maintainer identity metadata.
+
+### Slice 3 - Adapter integration and maintainer approval command
+1. In webhook intake, evaluate policy before guardrail intake result is returned.
+2. Map policy outcomes to deterministic webhook responses:
+   - `blocked` -> non-processing response with reason
+   - `requires_approval` -> non-processing response including run id
+   - `allow` -> existing accepted flow
+3. Implement `@remote-agent approve-run <run-id>` command:
+   - verify actor has maintainer-level permissions
+   - approve pending run in DB
+   - return explicit response message
+
+### Slice 4 - Auditable output and regression coverage
+1. Include policy/risk/decision fields in webhook responses where applicable.
+2. Extend tests:
+   - high-risk mutation requires approval
+   - protected path mention is blocked unless override token is present
+   - maintainer approve-run succeeds, non-maintainer fails
+3. Ensure existing dedupe/replay behavior remains unchanged.
+
+## Data/API Notes
+- Keep policy defaults conservative but configurable via environment variables.
+- Preserve existing webhook endpoint contract while adding explicit `policyDecision`, `riskTier`, and `reason` fields.
+
+## Edge Cases
+- Missing sender login for approval commands (deny approval)
+- Invalid run id on approval command
+- Approval command for non-`requires_approval` run
+- Unknown/unsupported command text should not escalate risk by default
+
+## Rollback Considerations
+- Migration is additive only.
+- Policy evaluation failures should fail closed for mutating commands and fail open for non-mutating comments where safe.
+
+## Verification Commands
+- `npm run type-check`
+- `npm run lint`
+- `npm test`
+- `npm --prefix webui run check`
+- `npm run build`
+
+## Execution Contract
+- **Issue:** `#31`
+- **Branch:** `feature/31-webhook-policy-engine-and-approval-gates`
+- **Plan file path:** `.agent/plans/31-webhook-policy-engine-and-approval-gates.md`

--- a/.agent/reports/execution-reports/2026-02-04-31-webhook-policy-engine-and-approval-gates.md
+++ b/.agent/reports/execution-reports/2026-02-04-31-webhook-policy-engine-and-approval-gates.md
@@ -1,0 +1,37 @@
+# Execution Report - Issue #31 Webhook Policy Engine and Approval Gates
+
+Date: 2026-02-04
+Issue: #31
+Branch: feature/31-webhook-policy-engine-and-approval-gates
+Plan: .agent/plans/31-webhook-policy-engine-and-approval-gates.md
+
+## Implemented
+- Added webhook policy evaluator module:
+  - `src/utils/webhook-policy.ts`
+  - `src/utils/webhook-policy.test.ts`
+- Extended webhook run persistence with policy and approval metadata:
+  - migration `migrations/010_webhook_policy_gates.sql`
+  - runtime schema compatibility updates in `src/db/schema.ts`
+  - DB flow updates in `src/db/webhook-control-plane.ts`
+- Added approval transition helper:
+  - `approveWebhookRun(runId, approvedBy)` in `src/db/webhook-control-plane.ts`
+- Integrated policy decisions into GitHub webhook ingest:
+  - risk/decision evaluation before execution intake
+  - deterministic statuses for `blocked_policy` and `requires_approval`
+  - maintainer-gated `approve-run <run-id>` command handling
+  - updated response payload traces (`policyDecision`, `riskTier`, `reason`)
+- Added regression tests for policy and approval flows:
+  - `src/adapters/github.test.ts`
+
+## Validation
+- `npm run type-check` ?
+- `npm run lint` ? (warnings-only baseline, no lint errors)
+- `npm test` ? (15 suites, 96 tests)
+- `npm --prefix webui run check` ?
+- `npm run build` ?
+
+## Notes
+- Existing untracked local report files were left untouched:
+  - `.agent/reports/pr-11-webui-layout.md`
+  - `.agent/reports/pr-12-webui-markdown.md`
+  - `.agent/reports/pr-13-webui-parity.md`

--- a/migrations/010_webhook_policy_gates.sql
+++ b/migrations/010_webhook_policy_gates.sql
@@ -1,0 +1,11 @@
+-- Migration 010: Webhook policy and approval gate metadata
+
+ALTER TABLE remote_agent_automation_runs
+  ADD COLUMN IF NOT EXISTS risk_tier VARCHAR(10),
+  ADD COLUMN IF NOT EXISTS policy_decision VARCHAR(30),
+  ADD COLUMN IF NOT EXISTS policy_reason TEXT,
+  ADD COLUMN IF NOT EXISTS approved_by VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS approved_at TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX IF NOT EXISTS idx_remote_agent_automation_runs_policy_decision
+  ON remote_agent_automation_runs(policy_decision, created_at DESC);

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -6,7 +6,10 @@ jest.mock('@octokit/rest', () => ({
   Octokit: jest.fn().mockImplementation(() => ({
     rest: {
       issues: { createComment: jest.fn() },
-      repos: { get: jest.fn().mockResolvedValue({ data: { default_branch: 'main' } }) }
+      repos: {
+        get: jest.fn().mockResolvedValue({ data: { default_branch: 'main' } }),
+        getCollaboratorPermissionLevel: jest.fn().mockResolvedValue({ data: { permission: 'write' } }),
+      }
     }
   }))
 }));
@@ -39,6 +42,7 @@ jest.mock('../db/webhook-control-plane', () => ({
   intakeWebhookRun: jest.fn(),
   finalizeWebhookRun: jest.fn(),
   registerWebhookFailure: jest.fn(),
+  approveWebhookRun: jest.fn(),
 }));
 jest.mock('../orchestrator/orchestrator', () => ({
   handleMessage: jest.fn()
@@ -50,6 +54,7 @@ describe('GitHubAdapter', () => {
     intakeWebhookRun: jest.Mock;
     finalizeWebhookRun: jest.Mock;
     registerWebhookFailure: jest.Mock;
+    approveWebhookRun: jest.Mock;
   };
 
   beforeEach(() => {
@@ -140,6 +145,123 @@ describe('GitHubAdapter', () => {
   });
 
   describe('ingestWebhook', () => {
+    test('returns requires_approval for high-risk policy decisions', async () => {
+      webhookDb.intakeWebhookRun.mockResolvedValueOnce({
+        decision: 'requires_approval',
+        chain: { id: 'chain-approval' },
+        run: { id: 'run-approval', reason: 'high_risk_requires_approval', risk_tier: 'high', policy_decision: 'requires_approval' },
+      });
+
+      const payload = JSON.stringify({
+        action: 'created',
+        issue: { number: 31, title: 'x', body: 'y', user: { login: 'u' }, labels: [], state: 'open' },
+        comment: { body: '@remote-agent /command-invoke auth migration change', user: { login: 'u' } },
+        repository: {
+          owner: { login: 'imKXNNY' },
+          name: 'Remote-Agentic-Coding-System',
+          full_name: 'imKXNNY/Remote-Agentic-Coding-System',
+          html_url: 'https://github.com/imKXNNY/Remote-Agentic-Coding-System',
+          default_branch: 'stable',
+        },
+        sender: { login: 'u' },
+      });
+
+      jest.spyOn(adapter as any, 'verifySignature').mockReturnValue(true);
+      const result = await adapter.ingestWebhook(payload, 'sha256=fake');
+
+      expect(result.shouldProcess).toBe(false);
+      expect(result.body).toEqual(
+        expect.objectContaining({
+          status: 'requires_approval',
+          runId: 'run-approval',
+          riskTier: 'high',
+        })
+      );
+    });
+
+    test('returns blocked policy when protected path appears', async () => {
+      webhookDb.intakeWebhookRun.mockResolvedValueOnce({
+        decision: 'blocked',
+        chain: { id: 'chain-blocked' },
+        run: { id: 'run-blocked', reason: 'protected_path_blocked', risk_tier: 'medium', policy_decision: 'blocked' },
+      });
+
+      const payload = JSON.stringify({
+        action: 'created',
+        issue: { number: 31, title: 'x', body: 'y', user: { login: 'u' }, labels: [], state: 'open' },
+        comment: { body: '@remote-agent /command-invoke edit .env', user: { login: 'u' } },
+        repository: {
+          owner: { login: 'imKXNNY' },
+          name: 'Remote-Agentic-Coding-System',
+          full_name: 'imKXNNY/Remote-Agentic-Coding-System',
+          html_url: 'https://github.com/imKXNNY/Remote-Agentic-Coding-System',
+          default_branch: 'stable',
+        },
+        sender: { login: 'u' },
+      });
+
+      jest.spyOn(adapter as any, 'verifySignature').mockReturnValue(true);
+      const result = await adapter.ingestWebhook(payload, 'sha256=fake');
+
+      expect(result.shouldProcess).toBe(false);
+      expect(result.body).toEqual(
+        expect.objectContaining({
+          status: 'blocked_policy',
+          runId: 'run-blocked',
+        })
+      );
+    });
+
+    test('approve-run command succeeds for maintainer', async () => {
+      webhookDb.approveWebhookRun.mockResolvedValueOnce({ id: 'run-1', chain_id: 'chain-1' });
+      const payload = JSON.stringify({
+        action: 'created',
+        issue: { number: 31, title: 'x', body: 'y', user: { login: 'u' }, labels: [], state: 'open' },
+        comment: { body: '@remote-agent approve-run run-1', user: { login: 'u' } },
+        repository: {
+          owner: { login: 'imKXNNY' },
+          name: 'Remote-Agentic-Coding-System',
+          full_name: 'imKXNNY/Remote-Agentic-Coding-System',
+          html_url: 'https://github.com/imKXNNY/Remote-Agentic-Coding-System',
+          default_branch: 'stable',
+        },
+        sender: { login: 'maintainer' },
+      });
+
+      jest.spyOn(adapter as any, 'verifySignature').mockReturnValue(true);
+      const result = await adapter.ingestWebhook(payload, 'sha256=fake');
+
+      expect(result.httpStatus).toBe(200);
+      expect(result.body).toEqual(expect.objectContaining({ status: 'approval_granted', runId: 'run-1' }));
+      expect(webhookDb.approveWebhookRun).toHaveBeenCalledWith('run-1', 'maintainer');
+    });
+
+    test('approve-run command fails for non-maintainer', async () => {
+      const octokit = (adapter as any).octokit;
+      octokit.rest.repos.getCollaboratorPermissionLevel.mockResolvedValueOnce({ data: { permission: 'read' } });
+
+      const payload = JSON.stringify({
+        action: 'created',
+        issue: { number: 31, title: 'x', body: 'y', user: { login: 'u' }, labels: [], state: 'open' },
+        comment: { body: '@remote-agent approve-run run-2', user: { login: 'u' } },
+        repository: {
+          owner: { login: 'imKXNNY' },
+          name: 'Remote-Agentic-Coding-System',
+          full_name: 'imKXNNY/Remote-Agentic-Coding-System',
+          html_url: 'https://github.com/imKXNNY/Remote-Agentic-Coding-System',
+          default_branch: 'stable',
+        },
+        sender: { login: 'reader' },
+      });
+
+      jest.spyOn(adapter as any, 'verifySignature').mockReturnValue(true);
+      const result = await adapter.ingestWebhook(payload, 'sha256=fake');
+
+      expect(result.httpStatus).toBe(403);
+      expect(result.body).toEqual(expect.objectContaining({ status: 'approval_denied' }));
+      expect(webhookDb.approveWebhookRun).not.toHaveBeenCalled();
+    });
+
     test('returns deduped intake result for duplicate delivery', async () => {
       webhookDb.intakeWebhookRun.mockResolvedValueOnce({
         decision: 'deduped',

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -18,6 +18,7 @@ import {
   buildWebhookDedupeKey,
   deriveWebhookDeliveryId,
 } from '../utils/webhook-control-plane';
+import { evaluateWebhookPolicy } from '../utils/webhook-policy';
 
 const execAsync = promisify(exec);
 
@@ -38,6 +39,7 @@ interface WebhookEvent {
     user: { login: string };
     state: string;
     head?: { sha: string };
+    ref?: string;
     changed_files?: number;
     additions?: number;
     deletions?: number;
@@ -264,6 +266,30 @@ export class GitHubAdapter implements IPlatformAdapter {
     const match = regex.exec(conversationId);
     if (!match) return null;
     return { owner: match[1], repo: match[2], number: parseInt(match[3], 10) };
+  }
+
+  private extractApproveRunId(comment: string): string | null {
+    const match = /^approve-run\s+([a-zA-Z0-9-]+)/i.exec(comment.trim());
+    return match?.[1] ?? null;
+  }
+
+  private async isMaintainer(owner: string, repo: string, username: string): Promise<boolean> {
+    try {
+      const { data } = await this.octokit.rest.repos.getCollaboratorPermissionLevel({
+        owner,
+        repo,
+        username,
+      });
+      return ['admin', 'maintain', 'write'].includes(data.permission);
+    } catch (error) {
+      console.warn('[GitHub] Failed to resolve maintainer permission', {
+        owner,
+        repo,
+        username,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
   }
 
   /**
@@ -521,7 +547,55 @@ ${triage.technical_summary}
     });
 
     const strippedComment = this.stripMention(comment);
+    const approveRunId = this.extractApproveRunId(strippedComment);
+    if (approveRunId) {
+      const actor = event.sender?.login;
+      if (!actor) {
+        return {
+          httpStatus: 400,
+          body: { status: 'approval_denied', reason: 'missing_actor' },
+          shouldProcess: false,
+        };
+      }
+
+      const canApprove = await this.isMaintainer(owner, repo, actor);
+      if (!canApprove) {
+        return {
+          httpStatus: 403,
+          body: { status: 'approval_denied', reason: 'maintainer_required', runId: approveRunId },
+          shouldProcess: false,
+        };
+      }
+
+      const approvedRun = await webhookDb.approveWebhookRun(approveRunId, actor);
+      if (!approvedRun) {
+        return {
+          httpStatus: 404,
+          body: { status: 'approval_not_found', runId: approveRunId },
+          shouldProcess: false,
+        };
+      }
+
+      return {
+        httpStatus: 200,
+        body: {
+          status: 'approval_granted',
+          runId: approvedRun.id,
+          chainId: approvedRun.chain_id,
+          approvedBy: actor,
+        },
+        shouldProcess: false,
+      };
+    }
+
     const isMutating = strippedComment.startsWith('/command-invoke');
+    const targetBranch = pullRequest?.ref ?? event.repository.default_branch;
+    const policy = evaluateWebhookPolicy({
+      repositoryFullName: event.repository.full_name,
+      targetBranch,
+      commandText: strippedComment,
+      isMutating,
+    });
 
     const intake = await webhookDb.intakeWebhookRun({
       platformType: 'github',
@@ -535,6 +609,9 @@ ${triage.technical_summary}
       action: event.action,
       headSha,
       isMutating,
+      policyDecision: policy.decision,
+      policyReason: policy.reason,
+      riskTier: policy.riskTier,
     });
 
     if (intake.decision === 'deduped') {
@@ -563,6 +640,8 @@ ${triage.technical_summary}
         body: {
           status: 'paused',
           reason: intake.run?.reason ?? intake.reason ?? 'guardrail_triggered',
+          riskTier: intake.run?.risk_tier ?? null,
+          policyDecision: intake.run?.policy_decision ?? null,
           chainId: intake.chain.id,
           runId: intake.run?.id ?? null,
         },
@@ -570,9 +649,45 @@ ${triage.technical_summary}
       };
     }
 
+    if (intake.decision === 'blocked') {
+      return {
+        httpStatus: 202,
+        body: {
+          status: 'blocked_policy',
+          reason: intake.reason ?? intake.run.reason ?? 'policy_blocked',
+          riskTier: intake.run.risk_tier,
+          policyDecision: intake.run.policy_decision,
+          chainId: intake.chain.id,
+          runId: intake.run.id,
+        },
+        shouldProcess: false,
+      };
+    }
+
+    if (intake.decision === 'requires_approval') {
+      return {
+        httpStatus: 202,
+        body: {
+          status: 'requires_approval',
+          reason: intake.reason ?? intake.run.reason ?? 'approval_required',
+          riskTier: intake.run.risk_tier,
+          policyDecision: intake.run.policy_decision,
+          chainId: intake.chain.id,
+          runId: intake.run.id,
+        },
+        shouldProcess: false,
+      };
+    }
+
     return {
       httpStatus: 202,
-      body: { status: 'accepted', chainId: intake.chain.id, runId: intake.run.id },
+      body: {
+        status: 'accepted',
+        chainId: intake.chain.id,
+        runId: intake.run.id,
+        riskTier: intake.run.risk_tier,
+        policyDecision: intake.run.policy_decision,
+      },
       shouldProcess: true,
       context: {
         runId: intake.run.id,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -70,6 +70,15 @@ export async function ensureSchemaCompatibility(): Promise<void> {
   `);
 
   await pool.query(`
+    ALTER TABLE remote_agent_automation_runs
+    ADD COLUMN IF NOT EXISTS risk_tier VARCHAR(10),
+    ADD COLUMN IF NOT EXISTS policy_decision VARCHAR(30),
+    ADD COLUMN IF NOT EXISTS policy_reason TEXT,
+    ADD COLUMN IF NOT EXISTS approved_by VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS approved_at TIMESTAMP WITH TIME ZONE
+  `);
+
+  await pool.query(`
     CREATE INDEX IF NOT EXISTS idx_remote_agent_automation_runs_chain_created
       ON remote_agent_automation_runs(chain_id, created_at DESC)
   `);

--- a/src/db/webhook-control-plane.ts
+++ b/src/db/webhook-control-plane.ts
@@ -5,6 +5,7 @@ import {
   evaluateWebhookGuardrails,
   isTerminalWebhookRunStatus,
 } from '../utils/webhook-control-plane';
+import { WebhookPolicyDecision, WebhookPolicyReason, WebhookRiskTier } from '../utils/webhook-policy';
 
 export interface WebhookChain {
   id: string;
@@ -35,6 +36,11 @@ export interface WebhookRun {
   reason: string | null;
   is_mutating: boolean;
   failure_signature: string | null;
+  risk_tier: WebhookRiskTier | null;
+  policy_decision: WebhookPolicyDecision | null;
+  policy_reason: WebhookPolicyReason | null;
+  approved_by: string | null;
+  approved_at: Date | null;
   started_at: Date | null;
   finished_at: Date | null;
   expires_at: Date | null;
@@ -53,10 +59,13 @@ interface IntakeWebhookRunInput {
   action: string;
   headSha?: string | null;
   isMutating: boolean;
+  policyDecision: WebhookPolicyDecision;
+  policyReason: WebhookPolicyReason;
+  riskTier: WebhookRiskTier;
 }
 
 interface IntakeDecision {
-  decision: 'accepted' | 'deduped' | 'replay_inflight' | 'paused';
+  decision: 'accepted' | 'deduped' | 'replay_inflight' | 'paused' | 'requires_approval' | 'blocked';
   run: WebhookRun | null;
   chain: WebhookChain;
   reason?: string;
@@ -139,6 +148,9 @@ export async function intakeWebhookRun(input: IntakeWebhookRunInput): Promise<In
         status: 'paused',
         reason: guardrail.reason,
         isMutating: input.isMutating,
+        riskTier: input.riskTier,
+        policyDecision: input.policyDecision,
+        policyReason: input.policyReason,
       });
       if (!pausedRun) {
         const replay = await findExistingDedupeRun(client, input.dedupeKey);
@@ -172,6 +184,73 @@ export async function intakeWebhookRun(input: IntakeWebhookRunInput): Promise<In
       };
     }
 
+    if (input.policyDecision === 'blocked') {
+      const blockedRun = await insertRun(client, {
+        chainId: chainAfterWindowReset.id,
+        deliveryId: input.deliveryId,
+        dedupeKey: input.dedupeKey,
+        eventType: input.eventType,
+        action: input.action,
+        headSha: input.headSha ?? null,
+        status: 'blocked_policy',
+        reason: input.policyReason,
+        isMutating: input.isMutating,
+        riskTier: input.riskTier,
+        policyDecision: input.policyDecision,
+        policyReason: input.policyReason,
+      });
+      if (!blockedRun) {
+        const replay = await findExistingDedupeRun(client, input.dedupeKey);
+        if (replay) {
+          await client.query('COMMIT');
+          return {
+            decision: isTerminalWebhookRunStatus(replay.status) ? 'deduped' : 'replay_inflight',
+            run: replay,
+            chain: chainAfterWindowReset,
+          };
+        }
+        throw new Error('Failed to insert blocked webhook run and no existing dedupe run found');
+      }
+      await client.query('COMMIT');
+      return { decision: 'blocked', run: blockedRun, chain: chainAfterWindowReset, reason: input.policyReason };
+    }
+
+    if (input.policyDecision === 'requires_approval') {
+      const approvalRun = await insertRun(client, {
+        chainId: chainAfterWindowReset.id,
+        deliveryId: input.deliveryId,
+        dedupeKey: input.dedupeKey,
+        eventType: input.eventType,
+        action: input.action,
+        headSha: input.headSha ?? null,
+        status: 'requires_approval',
+        reason: input.policyReason,
+        isMutating: input.isMutating,
+        riskTier: input.riskTier,
+        policyDecision: input.policyDecision,
+        policyReason: input.policyReason,
+      });
+      if (!approvalRun) {
+        const replay = await findExistingDedupeRun(client, input.dedupeKey);
+        if (replay) {
+          await client.query('COMMIT');
+          return {
+            decision: isTerminalWebhookRunStatus(replay.status) ? 'deduped' : 'replay_inflight',
+            run: replay,
+            chain: chainAfterWindowReset,
+          };
+        }
+        throw new Error('Failed to insert approval webhook run and no existing dedupe run found');
+      }
+      await client.query('COMMIT');
+      return {
+        decision: 'requires_approval',
+        run: approvalRun,
+        chain: chainAfterWindowReset,
+        reason: input.policyReason,
+      };
+    }
+
     const acceptedRun = await insertRun(client, {
       chainId: chainAfterWindowReset.id,
       deliveryId: input.deliveryId,
@@ -182,6 +261,9 @@ export async function intakeWebhookRun(input: IntakeWebhookRunInput): Promise<In
       status: 'accepted',
       reason: null,
       isMutating: input.isMutating,
+      riskTier: input.riskTier,
+      policyDecision: input.policyDecision,
+      policyReason: input.policyReason,
     });
     if (!acceptedRun) {
       const replay = await findExistingDedupeRun(client, input.dedupeKey);
@@ -318,6 +400,21 @@ export async function listRecentWebhookRuns(limit = 50): Promise<WebhookRun[]> {
   return result.rows;
 }
 
+export async function approveWebhookRun(runId: string, approvedBy: string): Promise<WebhookRun | null> {
+  const result = await pool.query<WebhookRun>(
+    `UPDATE remote_agent_automation_runs
+     SET status = 'accepted',
+         approved_by = $2,
+         approved_at = NOW(),
+         reason = COALESCE(reason, 'approved_by_maintainer')
+     WHERE id = $1
+       AND status = 'requires_approval'
+     RETURNING *`,
+    [runId, approvedBy]
+  );
+  return result.rows[0] ?? null;
+}
+
 interface InsertRunInput {
   chainId: string;
   deliveryId: string;
@@ -328,6 +425,9 @@ interface InsertRunInput {
   status: WebhookRunStatus;
   reason: string | null | undefined;
   isMutating: boolean;
+  riskTier: WebhookRiskTier;
+  policyDecision: WebhookPolicyDecision;
+  policyReason: WebhookPolicyReason;
 }
 
 async function findExistingDedupeRun(
@@ -349,9 +449,9 @@ async function findExistingDedupeRun(
 async function insertRun(client: { query: typeof pool.query }, input: InsertRunInput): Promise<WebhookRun | null> {
   const result = await client.query<WebhookRun>(
     `INSERT INTO remote_agent_automation_runs
-      (chain_id, delivery_id, dedupe_key, event_type, action, head_sha, status, reason, is_mutating, started_at, expires_at)
+      (chain_id, delivery_id, dedupe_key, event_type, action, head_sha, status, reason, is_mutating, risk_tier, policy_decision, policy_reason, started_at, expires_at)
      VALUES
-      ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW() + INTERVAL '24 hours')
+      ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW(), NOW() + INTERVAL '24 hours')
      ON CONFLICT (dedupe_key) DO NOTHING
      RETURNING *`,
     [
@@ -364,6 +464,9 @@ async function insertRun(client: { query: typeof pool.query }, input: InsertRunI
       input.status,
       input.reason ?? null,
       input.isMutating,
+      input.riskTier,
+      input.policyDecision,
+      input.policyReason,
     ]
   );
 

--- a/src/utils/webhook-policy.test.ts
+++ b/src/utils/webhook-policy.test.ts
@@ -1,0 +1,93 @@
+import { evaluateWebhookPolicy } from './webhook-policy';
+
+describe('webhook-policy evaluator', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.WEBHOOK_POLICY_ALLOWED_REPOS;
+    delete process.env.WEBHOOK_POLICY_ALLOWED_BRANCHES;
+    delete process.env.WEBHOOK_POLICY_ALLOWED_COMMANDS;
+    delete process.env.WEBHOOK_POLICY_PROTECTED_PATHS;
+    delete process.env.WEBHOOK_POLICY_REQUIRE_APPROVAL_FOR_MEDIUM;
+    delete process.env.WEBHOOK_POLICY_OVERRIDE_TOKEN;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('blocks repository outside allowlist', () => {
+    process.env.WEBHOOK_POLICY_ALLOWED_REPOS = 'imKXNNY/Remote-Agentic-Coding-System';
+    const result = evaluateWebhookPolicy({
+      repositoryFullName: 'other/repo',
+      targetBranch: 'feature/x',
+      commandText: '/command-invoke update docs',
+      isMutating: true,
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        decision: 'blocked',
+        reason: 'repo_not_allowed',
+      })
+    );
+  });
+
+  test('blocks protected path unless override token is present', () => {
+    const result = evaluateWebhookPolicy({
+      repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+      targetBranch: 'feature/x',
+      commandText: '/command-invoke edit .env',
+      isMutating: true,
+    });
+    expect(result.decision).toBe('blocked');
+    expect(result.reason).toBe('protected_path_blocked');
+
+    const override = evaluateWebhookPolicy({
+      repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+      targetBranch: 'feature/x',
+      commandText: '/command-invoke edit .env --policy-override',
+      isMutating: true,
+    });
+    expect(override.decision).not.toBe('blocked');
+  });
+
+  test('requires approval for high risk operations', () => {
+    const result = evaluateWebhookPolicy({
+      repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+      targetBranch: 'feature/x',
+      commandText: '/command-invoke update auth migration',
+      isMutating: true,
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        decision: 'requires_approval',
+        reason: 'high_risk_requires_approval',
+        riskTier: 'high',
+      })
+    );
+  });
+
+  test('requires approval for disallowed branch on mutating command', () => {
+    const result = evaluateWebhookPolicy({
+      repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+      targetBranch: 'stable',
+      commandText: '/command-invoke update tests',
+      isMutating: true,
+    });
+    expect(result.decision).toBe('requires_approval');
+    expect(result.reason).toBe('branch_not_allowed');
+  });
+
+  test('allows safe read-only command', () => {
+    const result = evaluateWebhookPolicy({
+      repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+      targetBranch: 'stable',
+      commandText: '/status',
+      isMutating: false,
+    });
+    expect(result.decision).toBe('allow');
+    expect(result.reason).toBe('policy_allow');
+    expect(result.riskTier).toBe('low');
+  });
+});

--- a/src/utils/webhook-policy.ts
+++ b/src/utils/webhook-policy.ts
@@ -1,0 +1,140 @@
+export type WebhookRiskTier = 'low' | 'medium' | 'high';
+export type WebhookPolicyDecision = 'allow' | 'requires_approval' | 'blocked';
+export type WebhookPolicyReason =
+  | 'repo_not_allowed'
+  | 'command_not_allowed'
+  | 'protected_path_blocked'
+  | 'branch_not_allowed'
+  | 'high_risk_requires_approval'
+  | 'medium_risk_requires_approval'
+  | 'policy_allow';
+
+export interface WebhookPolicyInput {
+  repositoryFullName: string;
+  targetBranch: string;
+  commandText: string;
+  isMutating: boolean;
+}
+
+export interface WebhookPolicyResult {
+  decision: WebhookPolicyDecision;
+  reason: WebhookPolicyReason;
+  riskTier: WebhookRiskTier;
+}
+
+function parseCsv(value: string | undefined, fallback: string[]): string[] {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = value
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean);
+  return parsed.length > 0 ? parsed : fallback;
+}
+
+function isPatternMatch(value: string, pattern: string): boolean {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`, 'i').test(value);
+}
+
+function matchesAny(value: string, patterns: string[]): boolean {
+  return patterns.some(pattern => isPatternMatch(value, pattern));
+}
+
+function extractPrimaryCommand(commandText: string): string {
+  return commandText.trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+}
+
+function classifyRisk(commandText: string, isMutating: boolean): WebhookRiskTier {
+  if (!isMutating) {
+    return 'low';
+  }
+
+  const text = commandText.toLowerCase();
+  const highRiskSignals = [
+    'migration',
+    'schema',
+    'auth',
+    'security',
+    'token',
+    'secret',
+    'release',
+    'deploy',
+    'package.json',
+    'dependency',
+    '.github/workflows',
+  ];
+  if (highRiskSignals.some(signal => text.includes(signal))) {
+    return 'high';
+  }
+
+  const lowRiskSignals = ['docs/', 'readme', 'test', 'report', '.md'];
+  if (lowRiskSignals.some(signal => text.includes(signal))) {
+    return 'low';
+  }
+
+  return 'medium';
+}
+
+function containsProtectedPath(commandText: string, protectedPaths: string[]): boolean {
+  const text = commandText.toLowerCase();
+  return protectedPaths.some(path => text.includes(path.toLowerCase()));
+}
+
+export function evaluateWebhookPolicy(input: WebhookPolicyInput): WebhookPolicyResult {
+  const allowedRepos = parseCsv(process.env.WEBHOOK_POLICY_ALLOWED_REPOS, ['*']);
+  const allowedBranches = parseCsv(process.env.WEBHOOK_POLICY_ALLOWED_BRANCHES, ['feature/*', 'fix/*', 'chore/*']);
+  const allowedCommands = parseCsv(process.env.WEBHOOK_POLICY_ALLOWED_COMMANDS, [
+    '/status',
+    '/help',
+    '/prime',
+    '/plan-feature',
+    '/execute',
+    '/code-review',
+    '/validate-simple',
+    '/execution-report',
+    '/command-invoke',
+    'approve-run',
+  ]).map(command => command.toLowerCase());
+  const protectedPaths = parseCsv(process.env.WEBHOOK_POLICY_PROTECTED_PATHS, [
+    '.env',
+    '.env.',
+    'secret',
+    'credentials',
+    'id_rsa',
+    'deploy_key',
+  ]);
+  const overrideToken = (process.env.WEBHOOK_POLICY_OVERRIDE_TOKEN ?? '--policy-override').toLowerCase();
+  const requireMediumApproval = process.env.WEBHOOK_POLICY_REQUIRE_APPROVAL_FOR_MEDIUM === 'true';
+
+  const primaryCommand = extractPrimaryCommand(input.commandText);
+  const riskTier = classifyRisk(input.commandText, input.isMutating);
+
+  if (!matchesAny(input.repositoryFullName, allowedRepos)) {
+    return { decision: 'blocked', reason: 'repo_not_allowed', riskTier };
+  }
+
+  if (primaryCommand && !allowedCommands.includes(primaryCommand)) {
+    return { decision: 'blocked', reason: 'command_not_allowed', riskTier };
+  }
+
+  const hasOverride = input.commandText.toLowerCase().includes(overrideToken);
+  if (containsProtectedPath(input.commandText, protectedPaths) && !hasOverride) {
+    return { decision: 'blocked', reason: 'protected_path_blocked', riskTier };
+  }
+
+  if (input.isMutating && !matchesAny(input.targetBranch, allowedBranches)) {
+    return { decision: 'requires_approval', reason: 'branch_not_allowed', riskTier };
+  }
+
+  if (riskTier === 'high') {
+    return { decision: 'requires_approval', reason: 'high_risk_requires_approval', riskTier };
+  }
+
+  if (riskTier === 'medium' && requireMediumApproval) {
+    return { decision: 'requires_approval', reason: 'medium_risk_requires_approval', riskTier };
+  }
+
+  return { decision: 'allow', reason: 'policy_allow', riskTier };
+}


### PR DESCRIPTION
## What/Why\nImplements issue #31 by adding webhook policy evaluation and approval gating for risky automation runs. This adds deterministic policy decisions (allow/requires_approval/blocked), maintainer approval transitions, and auditable policy metadata on webhook runs.\n\n## How tested\n- npm run type-check\n- npm run lint\n- npm test\n- npm --prefix webui run check\n- npm run build\n\n## Notes\n- Added migration: migrations/010_webhook_policy_gates.sql\n- Added plan + execution report artifacts under .agent/\n\nFixes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook policy engine evaluates risk and enforces access controls on incoming webhooks
  * Approval gates require maintainer sign-off for high-risk webhook operations
  * New approve-run command allows maintainers to approve pending executions via comments
  * Enhanced webhook tracking with policy decisions, risk tiers, and approval records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->