### PR TITLE
[#26] OpenClaw constrained interop bridge PoC

### DIFF
--- a/.agent/plans/26-openclaw-interop-bridge-poc.md
+++ b/.agent/plans/26-openclaw-interop-bridge-poc.md
@@ -1,0 +1,72 @@
+# Issue #26 - OpenClaw interop PoC: constrained webhook/event bridge
+
+Issue: `#26`
+Repo: `imKXNNY/Remote-Agentic-Coding-System`
+Date: 2026-02-04
+
+## Goal
+Implement a low-risk interoperability PoC where OpenClaw can send one inbound bridge event that triggers one constrained read-only action with strict safety guardrails and auditable run tracking.
+
+## Acceptance Criteria
+- [ ] End-to-end PoC demo documented.
+- [ ] Safety guards validated with at least one negative test scenario.
+- [ ] Decision memo created: continue, adjust, or stop.
+
+## Scope Contract (PoC)
+- Trigger source: one inbound event class (`openclaw.bridge.command`).
+- Action target: one constrained action (`/status` -> read-only status report).
+- Observability: include `eventId`, `runId`, `chainId` in responses and persist run lifecycle via control-plane ledger.
+
+## Safety Requirements Mapping
+- Allowed repository/branch allowlist -> enforced via `evaluateWebhookPolicy(...)`.
+- Idempotency key + replay protection -> `dedupeKey` + control-plane intake decisions.
+- Max-iteration / cooldown guard -> existing control-plane guardrail path.
+- Explicit command allowlist -> OpenClaw-specific allowlist (default only `/status`).
+
+## Touch Points
+- `src/routes/openclaw.ts` (new bridge route/handler)
+- `src/routes/openclaw.test.ts` (new route tests including negative safety path)
+- `src/index.ts` (mount OpenClaw webhook router)
+- `src/db/webhook-control-plane.ts` (extend intake platform type to include `openclaw`)
+- `docs/OpenClaw/analysis/` (PoC demo + decision memo)
+- `docs/OpenClaw/README.md` (index updates)
+- `.agent/reports/execution-reports/` (execution artifact)
+
+## Execution Slices
+
+### Slice 1 - Bridge ingress and safety envelope
+1. Add OpenClaw bridge POST endpoint (`/webhooks/openclaw/bridge`).
+2. Validate required payload fields and shared-secret header.
+3. Enforce OpenClaw command allowlist (default `/status`).
+4. Evaluate repository/branch guardrails through existing webhook policy evaluator.
+
+### Slice 2 - Control-plane integration and observability
+1. Extend intake platform type to support `openclaw`.
+2. Build deterministic dedupe keys from `eventId` + context.
+3. Reuse intake decisions for replay/paused/blocked/approval states.
+4. Return and log `eventId`, `runId`, and `chainId`.
+
+### Slice 3 - Constrained action implementation
+1. Implement one read-only action for `/status`.
+2. Action response includes loop-health snapshot from existing webhook metrics/runs queries.
+3. Finalize accepted runs as `executed`; register failure signatures on processing errors.
+
+### Slice 4 - Tests + docs + recommendation
+1. Add route tests for:
+   - happy path status command,
+   - negative path for disallowed command (explicit safety validation),
+   - replay/dedupe behavior signaling.
+2. Add PoC demo documentation (request/response example).
+3. Add decision memo (continue/adjust/stop).
+
+## Verification Commands
+- `npm run type-check`
+- `npm run lint`
+- `npm test`
+- `npm --prefix webui run check`
+- `npm run build`
+
+## Execution Contract
+- **Issue:** `#26`
+- **Branch:** `feature/26-openclaw-interop-bridge-poc`
+- **Plan file path:** `.agent/plans/26-openclaw-interop-bridge-poc.md`

--- a/.agent/reports/execution-reports/2026-02-04-26-openclaw-interop-bridge-poc.md
+++ b/.agent/reports/execution-reports/2026-02-04-26-openclaw-interop-bridge-poc.md
@@ -1,0 +1,51 @@
+# Execution Report - Issue #26 OpenClaw Interop PoC
+
+Date: 2026-02-04
+Issue: #26
+Branch: feature/26-openclaw-interop-bridge-poc
+Plan: .agent/plans/26-openclaw-interop-bridge-poc.md
+
+## Implemented
+- Added constrained OpenClaw bridge webhook endpoint:
+  - `POST /webhooks/openclaw/bridge`
+  - implementation: `src/routes/openclaw.ts`
+- Mounted OpenClaw bridge router in app bootstrap:
+  - `src/index.ts`
+- Reused control-plane run ledger for OpenClaw with platform support:
+  - `src/db/webhook-control-plane.ts` (`platformType` now supports `openclaw`)
+- Safety controls implemented:
+  - shared-secret header gate (`x-openclaw-shared-secret`)
+  - explicit OpenClaw command allowlist (`OPENCLAW_BRIDGE_ALLOWED_COMMANDS`, default `/status`)
+  - repo/branch policy checks through existing webhook policy evaluator
+  - dedupe/replay + iteration/cooldown guardrails through control-plane intake
+- Constrained action implemented:
+  - `/status` only -> returns read-only loop-health summary from existing metrics/runs queries
+- Observability linkage:
+  - responses include `eventId`, `runId`, and `chainId`
+  - run lifecycle events persist through existing control-plane event ledger
+- Added tests:
+  - `src/routes/openclaw.test.ts`
+  - includes negative safety scenario for disallowed command and replay handling
+- Added PoC docs:
+  - `docs/OpenClaw/analysis/interop-poc-demo.md`
+  - `docs/OpenClaw/analysis/interop-poc-decision.md`
+  - updated index: `docs/OpenClaw/README.md`
+
+## Acceptance Criteria Status
+- [x] End-to-end PoC demo documented.
+- [x] Safety guards validated with at least one negative test scenario.
+- [x] Decision memo created: continue, adjust, or stop. (continue, guarded expansion)
+
+## Validation
+- `npm run type-check` [PASS]
+- `npm run lint` [PASS] (warnings-only baseline, no lint errors)
+- `npm test` [PASS] (16 suites, 103 tests)
+- `npm --prefix webui run check` [PASS]
+- `npm run build` [PASS]
+
+## Notes
+- OpenClaw bridge remains intentionally narrow (single command) to keep blast radius low.
+- Existing unrelated untracked local report files remained untouched:
+  - `.agent/reports/pr-11-webui-layout.md`
+  - `.agent/reports/pr-12-webui-markdown.md`
+  - `.agent/reports/pr-13-webui-parity.md`

--- a/docs/OpenClaw/README.md
+++ b/docs/OpenClaw/README.md
@@ -6,6 +6,8 @@ This folder consolidates OpenClaw-related reference, research, and integration d
 - `reference/OpenClaw.README.md` - upstream OpenClaw reference snapshot.
 - `research/Perplexity_What-makes-ClawdBot-(shortly-Moltbot-now-Openclaw)-different.md` - exploratory comparison notes.
 - `analysis/integration-decision.md` - architecture-fit analysis and recommendation for this repo.
+- `analysis/interop-poc-demo.md` - end-to-end PoC request/response examples.
+- `analysis/interop-poc-decision.md` - PoC outcome and next-step decision.
 
 ## Current Decision
 See `analysis/integration-decision.md` for the latest recommendation and follow-up implementation roadmap.

--- a/docs/OpenClaw/analysis/interop-poc-decision.md
+++ b/docs/OpenClaw/analysis/interop-poc-decision.md
@@ -1,0 +1,32 @@
+# OpenClaw Interop PoC Decision Memo (Issue #26)
+
+Date: 2026-02-04
+Status: PoC completed
+
+## Decision
+**Continue (guarded expansion).**
+
+## Why
+- The PoC confirms low-risk interoperability can be achieved without replacing core architecture.
+- Safety controls are active through existing policy + control-plane guardrails:
+  - repo/branch allowlist (policy)
+  - command allowlist (OpenClaw route)
+  - dedupe/replay handling (control-plane)
+  - max-iteration and cooldown limits (control-plane)
+- Observability is preserved via run lifecycle records and response linkage (`eventId`, `runId`, `chainId`).
+
+## Limitations observed
+- Current PoC intentionally supports one command (`/status`) only.
+- Shared-secret header auth is minimal; stronger signed payload verification may be needed before broader exposure.
+
+## Recommended next step
+- Expand to one additional read-only command (for example `/webhook-metrics`) only after:
+  - production-like replay tests,
+  - secret-rotation guidance,
+  - tighter request-signature validation design.
+
+## Stop criteria
+Pause expansion if any of the following occur:
+- repeated policy bypass attempts,
+- evidence of replay abuse not mitigated by dedupe,
+- ambiguity around event source trust boundaries.

--- a/docs/OpenClaw/analysis/interop-poc-demo.md
+++ b/docs/OpenClaw/analysis/interop-poc-demo.md
@@ -1,0 +1,66 @@
+# OpenClaw Interop PoC Demo (Issue #26)
+
+Date: 2026-02-04
+Endpoint: `POST /webhooks/openclaw/bridge`
+Event class: `openclaw.bridge.command`
+Supported command(s): `/status`
+
+## Request Contract
+Headers:
+- `Content-Type: application/json`
+- `x-openclaw-shared-secret: <OPENCLAW_BRIDGE_SHARED_SECRET>`
+
+Body:
+```json
+{
+  "eventId": "evt-2026-02-04-0001",
+  "conversationId": "openclaw:thread:demo-1",
+  "repositoryFullName": "imKXNNY/Remote-Agentic-Coding-System",
+  "targetBranch": "stable",
+  "command": "/status"
+}
+```
+
+## Happy Path Demo
+```bash
+curl -X POST http://localhost:3000/webhooks/openclaw/bridge \
+  -H "Content-Type: application/json" \
+  -H "x-openclaw-shared-secret: $OPENCLAW_BRIDGE_SHARED_SECRET" \
+  -d '{
+    "eventId":"evt-2026-02-04-0001",
+    "conversationId":"openclaw:thread:demo-1",
+    "repositoryFullName":"imKXNNY/Remote-Agentic-Coding-System",
+    "targetBranch":"stable",
+    "command":"/status"
+  }'
+```
+
+Expected response shape:
+- `status: "executed"`
+- `eventId` echoed
+- `runId`, `chainId` included for audit linkage
+- `result` includes loop-health summary and recent run snapshot
+
+## Negative Safety Demo (command allowlist)
+```bash
+curl -X POST http://localhost:3000/webhooks/openclaw/bridge \
+  -H "Content-Type: application/json" \
+  -H "x-openclaw-shared-secret: $OPENCLAW_BRIDGE_SHARED_SECRET" \
+  -d '{
+    "eventId":"evt-2026-02-04-0002",
+    "conversationId":"openclaw:thread:demo-2",
+    "repositoryFullName":"imKXNNY/Remote-Agentic-Coding-System",
+    "command":"/execute"
+  }'
+```
+
+Expected response shape:
+- `status: "blocked_policy"`
+- `reason: "command_not_allowed"`
+- `runId`, `chainId` present
+- `allowedCommands` includes only allowlisted command(s)
+
+## Replay/Idempotency Demo
+Repeat an event with the same `eventId` and context:
+- expected status: `deduped` or `already_processing`
+- expected: same `runId` linkage returned by control-plane dedupe path

--- a/src/db/webhook-control-plane.ts
+++ b/src/db/webhook-control-plane.ts
@@ -438,15 +438,28 @@ export async function registerWebhookFailure(
   }
 }
 
-export async function listRecentWebhookRuns(limit = 50): Promise<WebhookRun[]> {
+export async function listRecentWebhookRuns(
+  limit = 50,
+  platformType?: string
+): Promise<WebhookRun[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 200);
-  const result = await pool.query<WebhookRun>(
-    `SELECT *
-     FROM remote_agent_automation_runs
-     ORDER BY created_at DESC
-     LIMIT $1`,
-    [safeLimit]
-  );
+  const result = platformType
+    ? await pool.query<WebhookRun>(
+        `SELECT r.*
+         FROM remote_agent_automation_runs r
+         INNER JOIN remote_agent_automation_chains c ON c.id = r.chain_id
+         WHERE c.platform_type = $1
+         ORDER BY r.created_at DESC
+         LIMIT $2`,
+        [platformType, safeLimit]
+      )
+    : await pool.query<WebhookRun>(
+        `SELECT r.*
+         FROM remote_agent_automation_runs r
+         ORDER BY r.created_at DESC
+         LIMIT $1`,
+        [safeLimit]
+      );
   return result.rows;
 }
 
@@ -463,20 +476,34 @@ export async function listWebhookRunEvents(runId: string, limit = 200): Promise<
   return result.rows;
 }
 
-export async function getWebhookMetrics(): Promise<WebhookMetrics> {
+export async function getWebhookMetrics(platformType?: string): Promise<WebhookMetrics> {
+  const params: string[] = [];
+  const joinClause = platformType
+    ? 'INNER JOIN remote_agent_automation_chains c ON c.id = r.chain_id'
+    : '';
+  const whereClause = platformType ? 'WHERE c.platform_type = $1' : '';
+  if (platformType) {
+    params.push(platformType);
+  }
+
   const statusCountsResult = await pool.query<{ status: string; count: string }>(
-    `SELECT status, COUNT(*)::text AS count
-     FROM remote_agent_automation_runs
-     GROUP BY status`
+    `SELECT r.status, COUNT(*)::text AS count
+     FROM remote_agent_automation_runs r
+     ${joinClause}
+     ${whereClause}
+     GROUP BY r.status`,
+    params
   );
 
   const durationResult = await pool.query<{ avg_seconds: string | null; p95_seconds: string | null }>(
     `SELECT
-       AVG(EXTRACT(EPOCH FROM (finished_at - started_at)))::text AS avg_seconds,
-       PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (finished_at - started_at)))::text AS p95_seconds
-     FROM remote_agent_automation_runs
-     WHERE started_at IS NOT NULL
-       AND finished_at IS NOT NULL`
+       AVG(EXTRACT(EPOCH FROM (r.finished_at - r.started_at)))::text AS avg_seconds,
+       PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (r.finished_at - r.started_at)))::text AS p95_seconds
+     FROM remote_agent_automation_runs r
+     ${joinClause}
+     ${whereClause ? `${whereClause} AND` : 'WHERE'} r.started_at IS NOT NULL
+       AND r.finished_at IS NOT NULL`,
+    params
   );
 
   const statusCounts = statusCountsResult.rows.reduce<Record<string, number>>((acc, row) => {

--- a/src/db/webhook-control-plane.ts
+++ b/src/db/webhook-control-plane.ts
@@ -75,7 +75,7 @@ export interface WebhookMetrics {
 }
 
 interface IntakeWebhookRunInput {
-  platformType: 'github';
+  platformType: 'github' | 'openclaw';
   conversationId: string;
   repositoryFullName: string;
   objectType: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { resolveWorkspacePath } from './utils/paths';
 import { startMcpServer } from './mcp-server';
 import uploadRouter from './routes/upload';
 import githubRouter from './routes/github';
+import openClawRouter from './routes/openclaw';
 import { asyncHandler } from './utils/async-handler';
 import { getGitHubAuthPreflight } from './utils/github-auth';
 
@@ -173,6 +174,9 @@ async function main(): Promise<void> {
 
   // JSON parsing for all other endpoints
   app.use(express.json());
+
+  // OpenClaw webhook bridge endpoint
+  app.use('/webhooks', openClawRouter);
 
   // Health check endpoints
   app.get('/health', (_req, res) => {

--- a/src/routes/openclaw.test.ts
+++ b/src/routes/openclaw.test.ts
@@ -188,7 +188,13 @@ describe('openclaw bridge route', () => {
     expect(finalizeWebhookRun).toHaveBeenCalledWith(
       'run-4',
       'paused',
-      expect.stringContaining('openclaw_bridge_error')
+      'openclaw_bridge_error'
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'execution_failed',
+        error: 'execution_failed',
+      })
     );
   });
 });

--- a/src/routes/openclaw.test.ts
+++ b/src/routes/openclaw.test.ts
@@ -29,10 +29,16 @@ function createResponse(): MockResponse {
 }
 
 describe('openclaw bridge route', () => {
+  const originalEnv = { ...process.env };
+
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.OPENCLAW_BRIDGE_SHARED_SECRET = 'secret-123';
     process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS = '/status';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
   });
 
   test('rejects requests with invalid secret', async () => {
@@ -150,5 +156,39 @@ describe('openclaw bridge route', () => {
       })
     );
     expect(registerWebhookFailure).not.toHaveBeenCalled();
+  });
+
+  test('returns execution_failed when command is allowlisted but not implemented', async () => {
+    process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS = '/status,/noop';
+    (intakeWebhookRun as unknown as jest.Mock).mockResolvedValueOnce({
+      decision: 'accepted',
+      chain: { id: 'chain-4' },
+      run: { id: 'run-4' },
+    });
+
+    const req = {
+      body: {
+        eventId: 'evt-4',
+        conversationId: 'openclaw:thread-4',
+        repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+        command: '/noop',
+      },
+      header: jest.fn().mockReturnValue('secret-123'),
+    } as unknown as Request;
+    const res = createResponse();
+
+    await postOpenClawBridgeHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(registerWebhookFailure).toHaveBeenCalledWith(
+      'chain-4',
+      'run-4',
+      expect.stringContaining('OPENCLAW_BRIDGE_ALLOWED_COMMANDS')
+    );
+    expect(finalizeWebhookRun).toHaveBeenCalledWith(
+      'run-4',
+      'paused',
+      expect.stringContaining('openclaw_bridge_error')
+    );
   });
 });

--- a/src/routes/openclaw.test.ts
+++ b/src/routes/openclaw.test.ts
@@ -1,0 +1,154 @@
+import type { Request, Response } from 'express';
+import { postOpenClawBridgeHandler } from './openclaw';
+import {
+  finalizeWebhookRun,
+  getWebhookMetrics,
+  intakeWebhookRun,
+  listRecentWebhookRuns,
+  registerWebhookFailure,
+} from '../db/webhook-control-plane';
+
+jest.mock('../db/webhook-control-plane', () => ({
+  intakeWebhookRun: jest.fn(),
+  getWebhookMetrics: jest.fn(),
+  listRecentWebhookRuns: jest.fn(),
+  finalizeWebhookRun: jest.fn(),
+  registerWebhookFailure: jest.fn(),
+}));
+
+type MockResponse = Response & {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+function createResponse(): MockResponse {
+  const res = {} as MockResponse;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('openclaw bridge route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.OPENCLAW_BRIDGE_SHARED_SECRET = 'secret-123';
+    process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS = '/status';
+  });
+
+  test('rejects requests with invalid secret', async () => {
+    const req = {
+      body: {},
+      header: jest.fn().mockReturnValue('wrong-secret'),
+    } as unknown as Request;
+    const res = createResponse();
+
+    await postOpenClawBridgeHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  test('executes /status command with run observability ids', async () => {
+    (intakeWebhookRun as unknown as jest.Mock).mockResolvedValueOnce({
+      decision: 'accepted',
+      chain: { id: 'chain-1' },
+      run: { id: 'run-1' },
+    });
+    (getWebhookMetrics as unknown as jest.Mock).mockResolvedValueOnce({
+      totals: {
+        totalRuns: 5,
+        executedRuns: 4,
+        blockedRuns: 1,
+        approvalRequiredRuns: 0,
+      },
+    });
+    (listRecentWebhookRuns as unknown as jest.Mock).mockResolvedValueOnce([
+      { id: 'run-a', status: 'executed', reason: null, created_at: new Date('2026-02-04T00:00:00Z') },
+    ]);
+
+    const req = {
+      body: {
+        eventId: 'evt-1',
+        conversationId: 'openclaw:thread-1',
+        repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+        targetBranch: 'stable',
+        command: '/status',
+      },
+      header: jest.fn().mockReturnValue('secret-123'),
+    } as unknown as Request;
+    const res = createResponse();
+
+    await postOpenClawBridgeHandler(req, res);
+
+    expect(intakeWebhookRun).toHaveBeenCalled();
+    expect(finalizeWebhookRun).toHaveBeenCalledWith('run-1', 'executed', 'openclaw_status_report');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'executed',
+        eventId: 'evt-1',
+        runId: 'run-1',
+        chainId: 'chain-1',
+      })
+    );
+  });
+
+  test('blocks disallowed command and returns policy reason', async () => {
+    (intakeWebhookRun as unknown as jest.Mock).mockResolvedValueOnce({
+      decision: 'blocked',
+      chain: { id: 'chain-2' },
+      run: { id: 'run-2', reason: 'command_not_allowed' },
+      reason: 'command_not_allowed',
+    });
+
+    const req = {
+      body: {
+        eventId: 'evt-2',
+        conversationId: 'openclaw:thread-2',
+        repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+        command: '/execute dangerous',
+      },
+      header: jest.fn().mockReturnValue('secret-123'),
+    } as unknown as Request;
+    const res = createResponse();
+
+    await postOpenClawBridgeHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'blocked_policy',
+        reason: 'command_not_allowed',
+      })
+    );
+  });
+
+  test('handles replay/in-flight dedupe responses', async () => {
+    (intakeWebhookRun as unknown as jest.Mock).mockResolvedValueOnce({
+      decision: 'replay_inflight',
+      chain: { id: 'chain-3' },
+      run: { id: 'run-3' },
+    });
+
+    const req = {
+      body: {
+        eventId: 'evt-3',
+        conversationId: 'openclaw:thread-3',
+        repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+        command: '/status',
+      },
+      header: jest.fn().mockReturnValue('secret-123'),
+    } as unknown as Request;
+    const res = createResponse();
+
+    await postOpenClawBridgeHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'already_processing',
+        runId: 'run-3',
+      })
+    );
+    expect(registerWebhookFailure).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/openclaw.test.ts
+++ b/src/routes/openclaw.test.ts
@@ -86,6 +86,8 @@ describe('openclaw bridge route', () => {
     await postOpenClawBridgeHandler(req, res);
 
     expect(intakeWebhookRun).toHaveBeenCalled();
+    expect(getWebhookMetrics).toHaveBeenCalledWith('openclaw');
+    expect(listRecentWebhookRuns).toHaveBeenCalledWith(5, 'openclaw');
     expect(finalizeWebhookRun).toHaveBeenCalledWith('run-1', 'executed', 'openclaw_status_report');
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(
@@ -124,6 +126,11 @@ describe('openclaw bridge route', () => {
       expect.objectContaining({
         status: 'blocked_policy',
         reason: 'command_not_allowed',
+      })
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        allowedCommands: expect.any(Array),
       })
     );
   });

--- a/src/routes/openclaw.ts
+++ b/src/routes/openclaw.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash, timingSafeEqual } from 'crypto';
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import {
@@ -139,7 +139,16 @@ export async function postOpenClawBridgeHandler(req: Request, res: Response): Pr
   }
 
   const providedSecret = req.header('x-openclaw-shared-secret')?.trim();
-  if (!providedSecret || providedSecret !== configuredSecret) {
+  if (!providedSecret) {
+    res.status(401).json({ status: 'invalid_secret' });
+    return;
+  }
+  const providedBuffer = Buffer.from(providedSecret, 'utf8');
+  const configuredBuffer = Buffer.from(configuredSecret, 'utf8');
+  if (
+    providedBuffer.length !== configuredBuffer.length ||
+    !timingSafeEqual(providedBuffer, configuredBuffer)
+  ) {
     res.status(401).json({ status: 'invalid_secret' });
     return;
   }
@@ -239,25 +248,31 @@ export async function postOpenClawBridgeHandler(req: Request, res: Response): Pr
   const chainId = intake.chain.id;
 
   try {
-    if (commandToken !== '/status') {
-      throw new Error(`Unsupported OpenClaw bridge command: ${commandToken}`);
+    if (!allowedCommands.includes(commandToken)) {
+      throw new Error(`Command not allowlisted: ${commandToken}`);
     }
 
-    const summary = await executeStatusReport(commandToken);
-    await finalizeWebhookRun(runId, 'executed', 'openclaw_status_report');
+    if (commandToken === '/status') {
+      const summary = await executeStatusReport(commandToken);
+      await finalizeWebhookRun(runId, 'executed', 'openclaw_status_report');
 
-    res.status(200).json({
-      status: 'executed',
-      eventId: payload.eventId,
-      runId,
-      chainId,
-      result: summary,
-    });
-    return;
+      res.status(200).json({
+        status: 'executed',
+        eventId: payload.eventId,
+        runId,
+        chainId,
+        result: summary,
+      });
+      return;
+    }
+
+    throw new Error(
+      `Command "${commandToken}" is allowlisted by OPENCLAW_BRIDGE_ALLOWED_COMMANDS but not implemented`
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await registerWebhookFailure(chainId, runId, message);
-    await finalizeWebhookRun(runId, 'blocked_policy', `openclaw_bridge_error:${message}`);
+    await finalizeWebhookRun(runId, 'paused', `openclaw_bridge_error:${message}`);
 
     res.status(500).json({
       status: 'execution_failed',

--- a/src/routes/openclaw.ts
+++ b/src/routes/openclaw.ts
@@ -112,7 +112,10 @@ function buildPolicy(
 }
 
 async function executeStatusReport(command: string): Promise<OpenClawStatusSummary> {
-  const [metrics, recentRuns] = await Promise.all([getWebhookMetrics(), listRecentWebhookRuns(5)]);
+  const [metrics, recentRuns] = await Promise.all([
+    getWebhookMetrics('openclaw'),
+    listRecentWebhookRuns(5, 'openclaw'),
+  ]);
 
   return {
     command,
@@ -232,7 +235,6 @@ export async function postOpenClawBridgeHandler(req: Request, res: Response): Pr
       runId: intake.run.id,
       chainId: intake.chain.id,
       reason: intake.reason ?? intake.run.reason ?? 'policy_blocked',
-      allowedCommands,
     });
     return;
   }

--- a/src/routes/openclaw.ts
+++ b/src/routes/openclaw.ts
@@ -145,10 +145,12 @@ export async function postOpenClawBridgeHandler(req: Request, res: Response): Pr
   }
   const providedBuffer = Buffer.from(providedSecret, 'utf8');
   const configuredBuffer = Buffer.from(configuredSecret, 'utf8');
-  if (
-    providedBuffer.length !== configuredBuffer.length ||
-    !timingSafeEqual(providedBuffer, configuredBuffer)
-  ) {
+  const maxLength = Math.max(providedBuffer.length, configuredBuffer.length);
+  const paddedProvided = Buffer.alloc(maxLength);
+  const paddedConfigured = Buffer.alloc(maxLength);
+  providedBuffer.copy(paddedProvided);
+  configuredBuffer.copy(paddedConfigured);
+  if (!timingSafeEqual(paddedProvided, paddedConfigured)) {
     res.status(401).json({ status: 'invalid_secret' });
     return;
   }

--- a/src/routes/openclaw.ts
+++ b/src/routes/openclaw.ts
@@ -68,7 +68,9 @@ function parsePayload(req: Request): OpenClawBridgePayload | null {
   const conversationId = typeof body.conversationId === 'string' ? body.conversationId.trim() : '';
   const repositoryFullName =
     typeof body.repositoryFullName === 'string' ? body.repositoryFullName.trim() : '';
-  const targetBranch = typeof body.targetBranch === 'string' ? body.targetBranch.trim() : undefined;
+  const targetBranchRaw =
+    typeof body.targetBranch === 'string' ? body.targetBranch.trim() : '';
+  const targetBranch = targetBranchRaw || undefined;
   const command = typeof body.command === 'string' ? body.command.trim() : '';
 
   if (!eventId || !conversationId || !repositoryFullName || !command) {

--- a/src/routes/openclaw.ts
+++ b/src/routes/openclaw.ts
@@ -271,15 +271,16 @@ export async function postOpenClawBridgeHandler(req: Request, res: Response): Pr
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const publicError = 'execution_failed';
     await registerWebhookFailure(chainId, runId, message);
-    await finalizeWebhookRun(runId, 'paused', `openclaw_bridge_error:${message}`);
+    await finalizeWebhookRun(runId, 'paused', 'openclaw_bridge_error');
 
     res.status(500).json({
       status: 'execution_failed',
       eventId: payload.eventId,
       runId,
       chainId,
-      error: message,
+      error: publicError,
     });
     return;
   }

--- a/src/routes/openclaw.ts
+++ b/src/routes/openclaw.ts
@@ -1,0 +1,275 @@
+import { createHash } from 'crypto';
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import {
+  finalizeWebhookRun,
+  getWebhookMetrics,
+  intakeWebhookRun,
+  listRecentWebhookRuns,
+  registerWebhookFailure,
+} from '../db/webhook-control-plane';
+import { buildWebhookDedupeKey } from '../utils/webhook-control-plane';
+import { evaluateWebhookPolicy, type WebhookPolicyResult } from '../utils/webhook-policy';
+import { asyncHandler } from '../utils/async-handler';
+
+const router = Router();
+
+interface OpenClawBridgePayload {
+  eventId: string;
+  conversationId: string;
+  repositoryFullName: string;
+  targetBranch?: string;
+  command: string;
+}
+
+interface OpenClawStatusSummary {
+  command: string;
+  totalRuns: number;
+  executedRuns: number;
+  blockedRuns: number;
+  approvalRequiredRuns: number;
+  recentRuns: {
+    id: string;
+    status: string;
+    reason: string | null;
+    created_at: Date;
+  }[];
+}
+
+function parseCsv(value: string | undefined, fallback: string[]): string[] {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = value
+    .split(',')
+    .map(part => part.trim().toLowerCase())
+    .filter(Boolean);
+
+  return parsed.length > 0 ? parsed : fallback;
+}
+
+function getOpenClawAllowedCommands(): string[] {
+  return parseCsv(process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS, ['/status']);
+}
+
+function toDeterministicObjectNumber(conversationId: string): number {
+  const hash = createHash('sha256').update(conversationId).digest('hex').slice(0, 8);
+  const parsed = Number.parseInt(hash, 16);
+  if (!Number.isFinite(parsed)) {
+    return 1;
+  }
+  return (parsed % 2_000_000_000) + 1;
+}
+
+function parsePayload(req: Request): OpenClawBridgePayload | null {
+  const body = req.body as Partial<OpenClawBridgePayload>;
+  const eventId = typeof body.eventId === 'string' ? body.eventId.trim() : '';
+  const conversationId = typeof body.conversationId === 'string' ? body.conversationId.trim() : '';
+  const repositoryFullName =
+    typeof body.repositoryFullName === 'string' ? body.repositoryFullName.trim() : '';
+  const targetBranch = typeof body.targetBranch === 'string' ? body.targetBranch.trim() : undefined;
+  const command = typeof body.command === 'string' ? body.command.trim() : '';
+
+  if (!eventId || !conversationId || !repositoryFullName || !command) {
+    return null;
+  }
+
+  return {
+    eventId,
+    conversationId,
+    repositoryFullName,
+    targetBranch,
+    command,
+  };
+}
+
+function extractCommandToken(command: string): string {
+  return command.split(/\s+/)[0]?.toLowerCase() ?? '';
+}
+
+function buildPolicy(
+  payload: OpenClawBridgePayload,
+  commandToken: string,
+  allowedCommands: string[]
+): WebhookPolicyResult {
+  if (!allowedCommands.includes(commandToken)) {
+    return {
+      decision: 'blocked',
+      reason: 'command_not_allowed',
+      riskTier: 'low',
+    };
+  }
+
+  return evaluateWebhookPolicy({
+    repositoryFullName: payload.repositoryFullName,
+    targetBranch: payload.targetBranch ?? 'stable',
+    commandText: payload.command,
+    isMutating: false,
+  });
+}
+
+async function executeStatusReport(command: string): Promise<OpenClawStatusSummary> {
+  const [metrics, recentRuns] = await Promise.all([getWebhookMetrics(), listRecentWebhookRuns(5)]);
+
+  return {
+    command,
+    totalRuns: metrics.totals.totalRuns,
+    executedRuns: metrics.totals.executedRuns,
+    blockedRuns: metrics.totals.blockedRuns,
+    approvalRequiredRuns: metrics.totals.approvalRequiredRuns,
+    recentRuns: recentRuns.map(run => ({
+      id: run.id,
+      status: run.status,
+      reason: run.reason,
+      created_at: run.created_at,
+    })),
+  };
+}
+
+/**
+ * POST /webhooks/openclaw/bridge
+ * Constrained OpenClaw interoperability PoC endpoint.
+ */
+export async function postOpenClawBridgeHandler(req: Request, res: Response): Promise<void> {
+  const configuredSecret = process.env.OPENCLAW_BRIDGE_SHARED_SECRET?.trim();
+  if (!configuredSecret) {
+    res.status(503).json({ error: 'OpenClaw bridge not configured' });
+    return;
+  }
+
+  const providedSecret = req.header('x-openclaw-shared-secret')?.trim();
+  if (!providedSecret || providedSecret !== configuredSecret) {
+    res.status(401).json({ status: 'invalid_secret' });
+    return;
+  }
+
+  const payload = parsePayload(req);
+  if (!payload) {
+    res.status(400).json({ error: 'Invalid payload for OpenClaw bridge command' });
+    return;
+  }
+
+  const commandToken = extractCommandToken(payload.command);
+  const allowedCommands = getOpenClawAllowedCommands();
+  const policy = buildPolicy(payload, commandToken, allowedCommands);
+
+  const objectNumber = toDeterministicObjectNumber(payload.conversationId);
+  const dedupeKey = buildWebhookDedupeKey({
+    deliveryId: payload.eventId,
+    repositoryFullName: payload.repositoryFullName,
+    objectType: 'openclaw_bridge',
+    objectNumber,
+    action: commandToken,
+    headSha: null,
+  });
+
+  const intake = await intakeWebhookRun({
+    platformType: 'openclaw',
+    conversationId: payload.conversationId,
+    repositoryFullName: payload.repositoryFullName,
+    objectType: 'openclaw_bridge',
+    objectNumber,
+    deliveryId: payload.eventId,
+    dedupeKey,
+    eventType: 'openclaw.bridge.command',
+    action: commandToken,
+    headSha: null,
+    isMutating: false,
+    policyDecision: policy.decision,
+    policyReason: policy.reason,
+    riskTier: policy.riskTier,
+  });
+
+  if (intake.decision === 'deduped') {
+    res.status(200).json({
+      status: 'deduped',
+      eventId: payload.eventId,
+      runId: intake.run?.id ?? null,
+      chainId: intake.chain.id,
+    });
+    return;
+  }
+
+  if (intake.decision === 'replay_inflight') {
+    res.status(202).json({
+      status: 'already_processing',
+      eventId: payload.eventId,
+      runId: intake.run?.id ?? null,
+      chainId: intake.chain.id,
+    });
+    return;
+  }
+
+  if (intake.decision === 'paused' || !intake.run) {
+    res.status(202).json({
+      status: 'paused',
+      eventId: payload.eventId,
+      runId: intake.run?.id ?? null,
+      chainId: intake.chain.id,
+      reason: intake.run?.reason ?? intake.reason ?? 'guardrail_triggered',
+    });
+    return;
+  }
+
+  if (intake.decision === 'blocked') {
+    res.status(202).json({
+      status: 'blocked_policy',
+      eventId: payload.eventId,
+      runId: intake.run.id,
+      chainId: intake.chain.id,
+      reason: intake.reason ?? intake.run.reason ?? 'policy_blocked',
+      allowedCommands,
+    });
+    return;
+  }
+
+  if (intake.decision === 'requires_approval') {
+    res.status(202).json({
+      status: 'requires_approval',
+      eventId: payload.eventId,
+      runId: intake.run.id,
+      chainId: intake.chain.id,
+      reason: intake.reason ?? intake.run.reason ?? 'approval_required',
+    });
+    return;
+  }
+
+  const runId = intake.run.id;
+  const chainId = intake.chain.id;
+
+  try {
+    if (commandToken !== '/status') {
+      throw new Error(`Unsupported OpenClaw bridge command: ${commandToken}`);
+    }
+
+    const summary = await executeStatusReport(commandToken);
+    await finalizeWebhookRun(runId, 'executed', 'openclaw_status_report');
+
+    res.status(200).json({
+      status: 'executed',
+      eventId: payload.eventId,
+      runId,
+      chainId,
+      result: summary,
+    });
+    return;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await registerWebhookFailure(chainId, runId, message);
+    await finalizeWebhookRun(runId, 'blocked_policy', `openclaw_bridge_error:${message}`);
+
+    res.status(500).json({
+      status: 'execution_failed',
+      eventId: payload.eventId,
+      runId,
+      chainId,
+      error: message,
+    });
+    return;
+  }
+}
+
+router.post('/openclaw/bridge', asyncHandler(postOpenClawBridgeHandler));
+
+export default router;


### PR DESCRIPTION
## What / Why
- add a constrained OpenClaw webhook bridge endpoint for low-risk loose interoperability
- support exactly one PoC event/action flow (openclaw.bridge.command -> /status read-only report)
- enforce safety controls: shared-secret gate, explicit command allowlist, repo/branch policy checks, dedupe/replay, iteration/cooldown guardrails
- reuse webhook control-plane observability and return event/run linkage (eventId, unId, chainId)

## How tested
- npm run type-check
- npm run lint
- npm test
- npm --prefix webui run check
- npm run build

## Artifacts
- Plan: .agent/plans/26-openclaw-interop-bridge-poc.md
- Execution report: .agent/reports/execution-reports/2026-02-04-26-openclaw-interop-bridge-poc.md
- PoC demo: docs/OpenClaw/analysis/interop-poc-demo.md
- Decision memo: docs/OpenClaw/analysis/interop-poc-decision.md

Fixes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenClaw webhook bridge: guarded read-only /status command, secret authentication, replay/dedupe protection, observability IDs, and platform support for OpenClaw webhooks.

* **Documentation**
  * Added Interop PoC docs: demo scenarios, decision memo, acceptance criteria, and README updates.

* **Tests**
  * Added tests for auth, allowed/blocked commands, replay/idempotency, safety scenarios, and end-to-end status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->