### PR TITLE
[#43] Guard WebUI conversation routes against non-UUID ids

### DIFF
--- a/.agent/plans/43-webui-conversation-id-uuid-guard.md
+++ b/.agent/plans/43-webui-conversation-id-uuid-guard.md
@@ -1,0 +1,23 @@
+# Issue #43 - WebUI UUID guard for temporary conversation IDs
+
+## Goal
+Prevent Postgres UUID parse errors when WebUI requests context/commands for temporary conversation ids like `default-<timestamp>`.
+
+## Acceptance Criteria
+- [ ] `/api/conversations/:id/context` handles non-UUID ids deterministically without 500.
+- [ ] `/api/conversations/:id/commands` handles non-UUID ids deterministically without 500.
+- [ ] No DB query is executed for invalid UUID ids in these routes.
+- [ ] Regression tests exist for `default-<timestamp>` style ids.
+
+## Files to change
+- `src/index.ts`
+- `src/utils/uuid.ts` (new)
+- `src/utils/uuid.test.ts` (new)
+- `src/db/messages.ts` (reuse helper)
+
+## Plan
+1. Add shared UUID validation helper.
+2. Use helper in affected WebUI routes before DB access.
+3. Reuse helper in `getMessages` to remove regex duplication.
+4. Add regression tests for helper behavior, including `default-<timestamp>`.
+5. Run type-check, lint, and targeted tests.

--- a/.agent/reports/execution-reports/2026-02-04-43-webui-uuid-guard.md
+++ b/.agent/reports/execution-reports/2026-02-04-43-webui-uuid-guard.md
@@ -1,0 +1,22 @@
+# Execution Report - Issue #43 WebUI UUID Guard
+
+## Summary
+Added UUID guards to WebUI conversation context/commands endpoints so temporary non-UUID conversation IDs do not hit Postgres UUID columns.
+
+## Changes
+- Added shared UUID helper:
+  - `src/utils/uuid.ts`
+  - `src/utils/uuid.test.ts`
+- Applied guard in WebUI routes:
+  - `GET /api/conversations/:id/context` returns 404 for non-UUID ids
+  - `GET /api/conversations/:id/commands` returns `{}` for non-UUID ids
+- Reused helper in message DB access:
+  - `src/db/messages.ts`
+
+## Validation
+- `npm run type-check` passed
+- `npm run lint` passed (warnings-only baseline)
+- `npm test -- src/utils/uuid.test.ts` passed
+
+## Notes
+This prevents `22P02` UUID parse errors for IDs like `default-<timestamp>` and keeps behavior deterministic.

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -2,6 +2,7 @@
  * Database operations for chat messages
  */
 import { pool } from './connection';
+import { isUuid } from '../utils/uuid';
 
 export interface Message {
   id: string;
@@ -26,8 +27,7 @@ export async function saveMessage(
 export async function getMessages(conversationId: string): Promise<Message[]> {
   // Gracefully handle non-UUID strings (like initial WebUI 'default-TIMESTAMP' IDs)
   // to avoid Postgres syntax errors.
-  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  if (!uuidRegex.test(conversationId)) {
+  if (!isUuid(conversationId)) {
     return [];
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import githubRouter from './routes/github';
 import openClawRouter from './routes/openclaw';
 import { asyncHandler } from './utils/async-handler';
 import { getGitHubAuthPreflight } from './utils/github-auth';
+import { isUuid } from './utils/uuid';
 
 // Extended WebSocket for heartbeat
 interface ExtWebSocket extends WebSocket {
@@ -348,6 +349,11 @@ async function main(): Promise<void> {
 
   app.get('/api/conversations/:id/context', authMiddleware, asyncHandler(async (req, res) => {
     try {
+      if (!isUuid(req.params.id)) {
+        res.status(404).json({ error: 'Conversation not found' });
+        return;
+      }
+
       const result = await pool.query<{ linked_issue: unknown }>(
         `SELECT linked_issue
          FROM remote_agent_conversations
@@ -381,6 +387,11 @@ async function main(): Promise<void> {
 
   app.get('/api/conversations/:id/commands', authMiddleware, asyncHandler(async (req, res) => {
     try {
+      if (!isUuid(req.params.id)) {
+        res.json({});
+        return;
+      }
+
       const convResult = await pool.query<{ codebase_id: string | null }>(
         'SELECT codebase_id FROM remote_agent_conversations WHERE id = $1',
         [req.params.id]

--- a/src/utils/uuid.test.ts
+++ b/src/utils/uuid.test.ts
@@ -1,0 +1,16 @@
+import { isUuid } from './uuid';
+
+describe('isUuid', () => {
+  test('returns true for valid uuid', () => {
+    expect(isUuid('123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+  });
+
+  test('returns false for temporary webui conversation id', () => {
+    expect(isUuid('default-1770197702599')).toBe(false);
+  });
+
+  test('returns false for empty string', () => {
+    expect(isUuid('')).toBe(false);
+  });
+});
+

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,6 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value);
+}
+


### PR DESCRIPTION
## What\n- add shared isUuid utility and tests\n- guard /api/conversations/:id/context to return 404 for non-UUID ids\n- guard /api/conversations/:id/commands to return {} for non-UUID ids\n- reuse UUID helper in messageDb.getMessages\n\n## Why\nWebUI temporary ids like default-<timestamp> were causing Postgres 22P02 UUID parse errors in logs.\n\n## How tested\n- 
pm run type-check\n- 
pm run lint (warnings-only baseline)\n- 
pm test -- src/utils/uuid.test.ts\n\nFixes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed database errors when temporary conversation IDs (e.g., default-<timestamp>) were used with conversation endpoints.

* **Improvements**
  * Conversation context and commands endpoints now properly validate conversation IDs before processing requests, returning appropriate responses for invalid IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->