### PR TITLE
feat: OpenClaw v2 curated command set + capability-aware policy (#40)

### DIFF
--- a/.agent/plans/40-openclaw-v2-curated-commands.md
+++ b/.agent/plans/40-openclaw-v2-curated-commands.md
@@ -1,0 +1,52 @@
+# Issue #40 - OpenClaw v2 Curated Commands + Capability Policy
+
+Issue: `#40`
+Repo: `imKXNNY/Remote-Agentic-Coding-System`
+Date: 2026-02-04
+
+## Goal
+Evolve OpenClaw bridge from PoC into a curated, capability-aware command surface with deterministic blocked/unsupported outcomes.
+
+## Acceptance Criteria
+- [ ] New commands are explicitly allowlisted and capability-classified.
+- [ ] Policy engine gates commands by capability/risk tier.
+- [ ] Tests cover allowed/blocked/unknown command paths.
+- [ ] Docs updated in `docs/OpenClaw/analysis/`.
+
+## Execution Contract
+- **Issue:** `#40`
+- **Branch:** `feature/40-openclaw-v2-curated-commands`
+- **Plan file path:** `.agent/plans/40-openclaw-v2-curated-commands.md`
+
+## Touch Points
+- `src/routes/openclaw.ts`
+- `src/routes/openclaw.test.ts`
+- `docs/OpenClaw/analysis/` (new v2 analysis doc)
+- `.agent/reports/execution-reports/` (execution report)
+
+## Slices
+
+### Slice 1 - Curated command registry + capability map
+1. Introduce explicit command registry with command token + capability (`read_only`, `needs_approval`, `mutating`).
+2. Filter registry via `OPENCLAW_BRIDGE_ALLOWED_COMMANDS` to produce effective allowlist.
+3. Add 2-3 additional read-only commands for OpenClaw bridge.
+
+### Slice 2 - Capability-aware policy and deterministic outcomes
+1. Evaluate policy with `isMutating` derived from command capability.
+2. Ensure blocked commands produce deterministic `blocked_policy` response payload.
+3. Ensure unsupported command implementations produce deterministic `unsupported_command` response payload.
+
+### Slice 3 - Tests + docs + validation
+1. Extend route tests to cover:
+   - new read-only commands
+   - unknown/disallowed command blocking
+   - capability-mutating path behavior
+   - deterministic unsupported response
+2. Add/update docs under `docs/OpenClaw/analysis/`.
+3. Run typecheck/lint/tests and write execution report.
+
+## Verification Commands
+- `npm run type-check`
+- `npm run lint`
+- `npm test -- src/routes/openclaw.test.ts`
+- `npm test`

--- a/.agent/reports/execution-reports/2026-02-04-40-openclaw-v2-curated-commands.md
+++ b/.agent/reports/execution-reports/2026-02-04-40-openclaw-v2-curated-commands.md
@@ -1,0 +1,35 @@
+# Execution Report - Issue #40 OpenClaw v2 Curated Commands
+
+## Summary
+Expanded the OpenClaw bridge from PoC to a curated command surface with capability-aware policy evaluation and deterministic blocked/unsupported responses.
+
+## Changes
+- Added OpenClaw command registry and capability map in `src/routes/openclaw.ts`:
+  - capabilities: `read_only`, `needs_approval`, `mutating`
+  - enabled command set derived from `OPENCLAW_BRIDGE_ALLOWED_COMMANDS`
+- Added new read-only commands:
+  - `/metrics`
+  - `/runs [limit]`
+  - `/events <runId> [limit]`
+- Enforced capability-aware policy behavior:
+  - mutating capability routes through policy as `isMutating=true`
+  - unknown command remains deterministic `blocked_policy`
+- Added deterministic unsupported handling:
+  - allowlisted-but-not-implemented command returns `501` with `unsupported_command`
+- Extended tests in `src/routes/openclaw.test.ts` for:
+  - new command success paths
+  - blocked unknown command path
+  - mutating capability approval behavior
+  - deterministic unsupported response
+- Added analysis doc:
+  - `docs/OpenClaw/analysis/openclaw-v2-curated-commands.md`
+
+## Validation
+- `npm run type-check` passed
+- `npm run lint` passed (warnings-only baseline)
+- `npm test -- src/routes/openclaw.test.ts` passed
+- `npm test` passed
+- `npm run build` passed
+
+## Notes
+`/events` intentionally returns a safe event subset (without raw metadata) to reduce accidental data leakage in OpenClaw command output.

--- a/docs/OpenClaw/analysis/openclaw-v2-curated-commands.md
+++ b/docs/OpenClaw/analysis/openclaw-v2-curated-commands.md
@@ -1,0 +1,34 @@
+# OpenClaw Bridge v2 - Curated Commands and Capability Policy
+
+Issue: #40  
+Date: 2026-02-04
+
+## What changed
+OpenClaw bridge moved from PoC single-command behavior to a curated command registry with explicit capabilities and deterministic outcomes.
+
+## Curated command set
+The bridge now resolves commands from a registry and then applies `OPENCLAW_BRIDGE_ALLOWED_COMMANDS` as an explicit enable-list.
+
+Default enabled commands:
+- `/status` (`read_only`) - aggregate status summary + recent runs
+- `/metrics` (`read_only`) - webhook metrics snapshot for OpenClaw platform
+- `/runs [limit]` (`read_only`) - recent run list (default `10`, max `50`)
+- `/events <runId> [limit]` (`read_only`) - event timeline for a run (default `20`, max `200`)
+
+Optional command class present for future workflow:
+- `/execute` (`mutating`) - intentionally not implemented yet; returns deterministic unsupported response if it passes policy and reaches execution.
+
+## Capability-aware policy behavior
+Capability now directly influences policy evaluation:
+- `read_only` -> evaluated as non-mutating (`isMutating=false`)
+- `mutating` -> evaluated as mutating (`isMutating=true`), which triggers branch/risk guardrails
+- `needs_approval` -> reserved class; auto-escalates to approval when base policy would allow
+
+## Deterministic outcomes
+- Unknown/disallowed command: `202` with `status: blocked_policy`, `reason: command_not_allowed`
+- Allowlisted-but-not-implemented command: `501` with `status: unsupported_command`
+- Runtime failure in implemented command: `500` with `status: execution_failed`
+
+## Notes
+- The `/events` command intentionally returns a safe subset (no raw metadata object), reducing accidental sensitive-data exposure in OpenClaw command responses.
+- This v2 keeps the surface intentionally small and auditable while extending operational usefulness beyond PoC.

--- a/src/routes/openclaw.test.ts
+++ b/src/routes/openclaw.test.ts
@@ -178,6 +178,45 @@ describe('openclaw bridge route', () => {
 
     expect(listWebhookRunEvents).toHaveBeenCalledWith('run-abc', 30);
     expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: [
+          expect.not.objectContaining({
+            metadata: expect.anything(),
+          }),
+        ],
+      })
+    );
+  });
+
+  test('returns 400 when /events is missing required runId argument', async () => {
+    (intakeWebhookRun as unknown as jest.Mock).mockResolvedValueOnce({
+      decision: 'accepted',
+      chain: { id: 'chain-e2' },
+      run: { id: 'run-e2' },
+    });
+
+    const req = {
+      body: {
+        eventId: 'evt-events-missing-runid',
+        conversationId: 'openclaw:events-missing',
+        repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+        command: '/events',
+      },
+      header: jest.fn().mockReturnValue('secret-123'),
+    } as unknown as Request;
+    const res = createResponse();
+
+    await postOpenClawBridgeHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(finalizeWebhookRun).toHaveBeenCalledWith('run-e2', 'paused', 'command_not_allowed');
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'invalid_command_arguments',
+        error: 'invalid_command_arguments',
+      })
+    );
   });
 
   test('blocks disallowed command and returns policy reason', async () => {

--- a/src/routes/openclaw.test.ts
+++ b/src/routes/openclaw.test.ts
@@ -5,6 +5,7 @@ import {
   getWebhookMetrics,
   intakeWebhookRun,
   listRecentWebhookRuns,
+  listWebhookRunEvents,
   registerWebhookFailure,
 } from '../db/webhook-control-plane';
 
@@ -12,6 +13,7 @@ jest.mock('../db/webhook-control-plane', () => ({
   intakeWebhookRun: jest.fn(),
   getWebhookMetrics: jest.fn(),
   listRecentWebhookRuns: jest.fn(),
+  listWebhookRunEvents: jest.fn(),
   finalizeWebhookRun: jest.fn(),
   registerWebhookFailure: jest.fn(),
 }));
@@ -34,7 +36,7 @@ describe('openclaw bridge route', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.OPENCLAW_BRIDGE_SHARED_SECRET = 'secret-123';
-    process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS = '/status';
+    process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS = '/status,/metrics,/runs,/events';
   });
 
   afterEach(() => {
@@ -91,7 +93,7 @@ describe('openclaw bridge route', () => {
       limit: 5,
       platformType: 'openclaw',
     });
-    expect(finalizeWebhookRun).toHaveBeenCalledWith('run-1', 'executed', 'openclaw_status_report');
+    expect(finalizeWebhookRun).toHaveBeenCalledWith('run-1', 'executed', 'openclaw_command_executed');
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -99,8 +101,83 @@ describe('openclaw bridge route', () => {
         eventId: 'evt-1',
         runId: 'run-1',
         chainId: 'chain-1',
+        command: '/status',
       })
     );
+  });
+
+  test('executes /metrics command', async () => {
+    (intakeWebhookRun as unknown as jest.Mock).mockResolvedValueOnce({
+      decision: 'accepted',
+      chain: { id: 'chain-m' },
+      run: { id: 'run-m' },
+    });
+    (getWebhookMetrics as unknown as jest.Mock).mockResolvedValueOnce({
+      totals: {
+        totalRuns: 11,
+        executedRuns: 9,
+        blockedRuns: 1,
+        approvalRequiredRuns: 1,
+      },
+      statusCounts: { executed: 9 },
+      durationSeconds: { avg: 2, p95: 4 },
+    });
+
+    const req = {
+      body: {
+        eventId: 'evt-metrics',
+        conversationId: 'openclaw:metrics',
+        repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+        command: '/metrics',
+      },
+      header: jest.fn().mockReturnValue('secret-123'),
+    } as unknown as Request;
+    const res = createResponse();
+
+    await postOpenClawBridgeHandler(req, res);
+
+    expect(getWebhookMetrics).toHaveBeenCalledWith('openclaw');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'executed',
+        command: '/metrics',
+      })
+    );
+  });
+
+  test('executes /events command and returns redacted-safe subset', async () => {
+    (intakeWebhookRun as unknown as jest.Mock).mockResolvedValueOnce({
+      decision: 'accepted',
+      chain: { id: 'chain-e' },
+      run: { id: 'run-e' },
+    });
+    (listWebhookRunEvents as unknown as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 'evt-raw-1',
+        event_type: 'run_created',
+        status: 'accepted',
+        message: 'created',
+        metadata: { token: 'secret' },
+        created_at: new Date('2026-02-04T00:00:00Z'),
+      },
+    ]);
+
+    const req = {
+      body: {
+        eventId: 'evt-events',
+        conversationId: 'openclaw:events',
+        repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+        command: '/events run-abc 30',
+      },
+      header: jest.fn().mockReturnValue('secret-123'),
+    } as unknown as Request;
+    const res = createResponse();
+
+    await postOpenClawBridgeHandler(req, res);
+
+    expect(listWebhookRunEvents).toHaveBeenCalledWith('run-abc', 30);
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 
   test('blocks disallowed command and returns policy reason', async () => {
@@ -116,7 +193,7 @@ describe('openclaw bridge route', () => {
         eventId: 'evt-2',
         conversationId: 'openclaw:thread-2',
         repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
-        command: '/execute dangerous',
+        command: '/unknown dangerous',
       },
       header: jest.fn().mockReturnValue('secret-123'),
     } as unknown as Request;
@@ -168,8 +245,8 @@ describe('openclaw bridge route', () => {
     expect(registerWebhookFailure).not.toHaveBeenCalled();
   });
 
-  test('returns execution_failed when command is allowlisted but not implemented', async () => {
-    process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS = '/status,/noop';
+  test('returns unsupported_command when command is allowlisted but not implemented', async () => {
+    process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS = '/status,/execute';
     (intakeWebhookRun as unknown as jest.Mock).mockResolvedValueOnce({
       decision: 'accepted',
       chain: { id: 'chain-4' },
@@ -181,7 +258,8 @@ describe('openclaw bridge route', () => {
         eventId: 'evt-4',
         conversationId: 'openclaw:thread-4',
         repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
-        command: '/noop',
+        targetBranch: 'feature/openclaw-v2',
+        command: '/execute',
       },
       header: jest.fn().mockReturnValue('secret-123'),
     } as unknown as Request;
@@ -189,21 +267,59 @@ describe('openclaw bridge route', () => {
 
     await postOpenClawBridgeHandler(req, res);
 
-    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.status).toHaveBeenCalledWith(501);
     expect(registerWebhookFailure).toHaveBeenCalledWith(
       'chain-4',
       'run-4',
-      expect.stringContaining('OPENCLAW_BRIDGE_ALLOWED_COMMANDS')
+      expect.stringContaining('allowlisted but not implemented')
     );
     expect(finalizeWebhookRun).toHaveBeenCalledWith(
       'run-4',
       'paused',
-      'openclaw_bridge_error'
+      'command_not_allowed'
     );
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        status: 'execution_failed',
-        error: 'execution_failed',
+        status: 'unsupported_command',
+        error: 'unsupported_command',
+      })
+    );
+  });
+
+  test('marks mutating capability commands as requiring approval on stable branch', async () => {
+    process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS = '/status,/execute';
+    (intakeWebhookRun as unknown as jest.Mock).mockResolvedValueOnce({
+      decision: 'requires_approval',
+      chain: { id: 'chain-5' },
+      run: { id: 'run-5', reason: 'branch_not_allowed' },
+      reason: 'branch_not_allowed',
+    });
+
+    const req = {
+      body: {
+        eventId: 'evt-5',
+        conversationId: 'openclaw:thread-5',
+        repositoryFullName: 'imKXNNY/Remote-Agentic-Coding-System',
+        targetBranch: 'stable',
+        command: '/execute update something',
+      },
+      header: jest.fn().mockReturnValue('secret-123'),
+    } as unknown as Request;
+    const res = createResponse();
+
+    await postOpenClawBridgeHandler(req, res);
+
+    expect(intakeWebhookRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: '/execute',
+        isMutating: true,
+        policyDecision: 'requires_approval',
+      })
+    );
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'requires_approval',
       })
     );
   });

--- a/src/routes/openclaw.ts
+++ b/src/routes/openclaw.ts
@@ -50,7 +50,19 @@ interface OpenClawCommandContext {
   args: string[];
 }
 
-class UnsupportedOpenClawCommandError extends Error {}
+class UnsupportedOpenClawCommandError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'UnsupportedOpenClawCommandError';
+  }
+}
+
+class OpenClawValidationError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'OpenClawValidationError';
+  }
+}
 
 function parseCsv(value: string | undefined, fallback: string[]): string[] {
   if (!value) {
@@ -156,7 +168,7 @@ function getOpenClawCommandRegistry(): Map<string, OpenClawCommandDefinition> {
       execute: async ({ args }): Promise<unknown> => {
         const runId = args[0]?.trim();
         if (!runId) {
-          throw new UnsupportedOpenClawCommandError('Command "/events" requires <runId> argument');
+          throw new OpenClawValidationError('Command "/events" requires <runId> argument');
         }
         const limit = parseOptionalLimit(args[1], 20, 200);
         const events = await listWebhookRunEvents(runId, limit);
@@ -393,12 +405,21 @@ export async function postOpenClawBridgeHandler(req: Request, res: Response): Pr
     return;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const isValidation = error instanceof OpenClawValidationError;
     const isUnsupported = error instanceof UnsupportedOpenClawCommandError;
-    const publicError = isUnsupported ? 'unsupported_command' : 'execution_failed';
+    const publicError = isValidation
+      ? 'invalid_command_arguments'
+      : isUnsupported
+        ? 'unsupported_command'
+        : 'execution_failed';
     await registerWebhookFailure(chainId, runId, message);
-    await finalizeWebhookRun(runId, 'paused', isUnsupported ? 'command_not_allowed' : 'openclaw_bridge_error');
+    await finalizeWebhookRun(
+      runId,
+      'paused',
+      isValidation || isUnsupported ? 'command_not_allowed' : 'openclaw_bridge_error'
+    );
 
-    res.status(isUnsupported ? 501 : 500).json({
+    res.status(isValidation ? 400 : isUnsupported ? 501 : 500).json({
       status: publicError,
       eventId: payload.eventId,
       runId,

--- a/src/routes/openclaw.ts
+++ b/src/routes/openclaw.ts
@@ -6,6 +6,7 @@ import {
   getWebhookMetrics,
   intakeWebhookRun,
   listRecentWebhookRuns,
+  listWebhookRunEvents,
   registerWebhookFailure,
 } from '../db/webhook-control-plane';
 import { buildWebhookDedupeKey } from '../utils/webhook-control-plane';
@@ -36,6 +37,21 @@ interface OpenClawStatusSummary {
   }[];
 }
 
+type OpenClawCommandCapability = 'read_only' | 'needs_approval' | 'mutating';
+
+interface OpenClawCommandDefinition {
+  token: string;
+  capability: OpenClawCommandCapability;
+  execute?: (context: OpenClawCommandContext) => Promise<unknown>;
+}
+
+interface OpenClawCommandContext {
+  commandToken: string;
+  args: string[];
+}
+
+class UnsupportedOpenClawCommandError extends Error {}
+
 function parseCsv(value: string | undefined, fallback: string[]): string[] {
   if (!value) {
     return fallback;
@@ -50,7 +66,7 @@ function parseCsv(value: string | undefined, fallback: string[]): string[] {
 }
 
 function getOpenClawAllowedCommands(): string[] {
-  return parseCsv(process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS, ['/status']);
+  return parseCsv(process.env.OPENCLAW_BRIDGE_ALLOWED_COMMANDS, ['/status', '/metrics', '/runs', '/events']);
 }
 
 function toDeterministicObjectNumber(conversationId: string): number {
@@ -86,16 +102,102 @@ function parsePayload(req: Request): OpenClawBridgePayload | null {
   };
 }
 
-function extractCommandToken(command: string): string {
-  return command.split(/\s+/)[0]?.toLowerCase() ?? '';
+function parseCommandParts(command: string): { token: string; args: string[] } {
+  const parts = command
+    .trim()
+    .split(/\s+/)
+    .map(part => part.trim())
+    .filter(Boolean);
+  const [token = '', ...args] = parts;
+  return {
+    token: token.toLowerCase(),
+    args,
+  };
+}
+
+function parseOptionalLimit(raw: string | undefined, fallback: number, max: number): number {
+  const parsed = Number.parseInt(raw ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.min(parsed, max);
+}
+
+function getOpenClawCommandRegistry(): Map<string, OpenClawCommandDefinition> {
+  const registry: OpenClawCommandDefinition[] = [
+    {
+      token: '/status',
+      capability: 'read_only',
+      execute: async ({ commandToken }) => executeStatusReport(commandToken),
+    },
+    {
+      token: '/metrics',
+      capability: 'read_only',
+      execute: async () => getWebhookMetrics('openclaw'),
+    },
+    {
+      token: '/runs',
+      capability: 'read_only',
+      execute: async ({ args }): Promise<unknown> => {
+        const limit = parseOptionalLimit(args[0], 10, 50);
+        const runs = await listRecentWebhookRuns({ limit, platformType: 'openclaw' });
+        return runs.map(run => ({
+          id: run.id,
+          status: run.status,
+          reason: run.reason,
+          created_at: run.created_at,
+          repository_full_name: run.repository_full_name ?? null,
+        }));
+      },
+    },
+    {
+      token: '/events',
+      capability: 'read_only',
+      execute: async ({ args }): Promise<unknown> => {
+        const runId = args[0]?.trim();
+        if (!runId) {
+          throw new UnsupportedOpenClawCommandError('Command "/events" requires <runId> argument');
+        }
+        const limit = parseOptionalLimit(args[1], 20, 200);
+        const events = await listWebhookRunEvents(runId, limit);
+        return events.map(event => ({
+          id: event.id,
+          event_type: event.event_type,
+          status: event.status,
+          message: event.message,
+          created_at: event.created_at,
+        }));
+      },
+    },
+    {
+      token: '/execute',
+      capability: 'mutating',
+    },
+  ];
+  return new Map(registry.map(definition => [definition.token, definition]));
+}
+
+function getEnabledCommandDefinitions(): Map<string, OpenClawCommandDefinition> {
+  const allowed = new Set(getOpenClawAllowedCommands().map(command => command.toLowerCase()));
+  const registry = getOpenClawCommandRegistry();
+  const enabled = new Map<string, OpenClawCommandDefinition>();
+  for (const [token, definition] of registry.entries()) {
+    if (allowed.has(token)) {
+      enabled.set(token, definition);
+    }
+  }
+  return enabled;
+}
+
+function isMutatingCapability(capability: OpenClawCommandCapability): boolean {
+  return capability === 'mutating';
 }
 
 function buildPolicy(
   payload: OpenClawBridgePayload,
-  commandToken: string,
-  allowedCommands: string[]
+  commandDefinition: OpenClawCommandDefinition | undefined
 ): WebhookPolicyResult {
-  if (!allowedCommands.includes(commandToken)) {
+  if (!commandDefinition) {
     return {
       decision: 'blocked',
       reason: 'command_not_allowed',
@@ -103,12 +205,22 @@ function buildPolicy(
     };
   }
 
-  return evaluateWebhookPolicy({
+  const policy = evaluateWebhookPolicy({
     repositoryFullName: payload.repositoryFullName,
     targetBranch: payload.targetBranch ?? 'stable',
     commandText: payload.command,
-    isMutating: false,
+    isMutating: isMutatingCapability(commandDefinition.capability),
   });
+
+  if (commandDefinition.capability === 'needs_approval' && policy.decision === 'allow') {
+    return {
+      decision: 'requires_approval',
+      reason: 'medium_risk_requires_approval',
+      riskTier: policy.riskTier === 'high' ? 'high' : 'medium',
+    };
+  }
+
+  return policy;
 }
 
 async function executeStatusReport(command: string): Promise<OpenClawStatusSummary> {
@@ -166,9 +278,11 @@ export async function postOpenClawBridgeHandler(req: Request, res: Response): Pr
     return;
   }
 
-  const commandToken = extractCommandToken(payload.command);
-  const allowedCommands = getOpenClawAllowedCommands();
-  const policy = buildPolicy(payload, commandToken, allowedCommands);
+  const parsedCommand = parseCommandParts(payload.command);
+  const commandToken = parsedCommand.token;
+  const enabledCommandDefinitions = getEnabledCommandDefinitions();
+  const commandDefinition = enabledCommandDefinitions.get(commandToken);
+  const policy = buildPolicy(payload, commandDefinition);
 
   const objectNumber = toDeterministicObjectNumber(payload.conversationId);
   const dedupeKey = buildWebhookDedupeKey({
@@ -191,7 +305,7 @@ export async function postOpenClawBridgeHandler(req: Request, res: Response): Pr
     eventType: 'openclaw.bridge.command',
     action: commandToken,
     headSha: null,
-    isMutating: false,
+    isMutating: commandDefinition ? isMutatingCapability(commandDefinition.capability) : false,
     policyDecision: policy.decision,
     policyReason: policy.reason,
     riskTier: policy.riskTier,
@@ -254,35 +368,38 @@ export async function postOpenClawBridgeHandler(req: Request, res: Response): Pr
   const chainId = intake.chain.id;
 
   try {
-    if (!allowedCommands.includes(commandToken)) {
-      throw new Error(`Command not allowlisted: ${commandToken}`);
+    if (!commandDefinition) {
+      throw new UnsupportedOpenClawCommandError(`Command "${commandToken}" is not enabled`);
+    }
+    if (!commandDefinition.execute) {
+      throw new UnsupportedOpenClawCommandError(
+        `Command "${commandToken}" is allowlisted but not implemented`
+      );
     }
 
-    if (commandToken === '/status') {
-      const summary = await executeStatusReport(commandToken);
-      await finalizeWebhookRun(runId, 'executed', 'openclaw_status_report');
-
-      res.status(200).json({
-        status: 'executed',
-        eventId: payload.eventId,
-        runId,
-        chainId,
-        result: summary,
-      });
-      return;
-    }
-
-    throw new Error(
-      `Command "${commandToken}" is allowlisted by OPENCLAW_BRIDGE_ALLOWED_COMMANDS but not implemented`
-    );
+    const result = await commandDefinition.execute({
+      commandToken,
+      args: parsedCommand.args,
+    });
+    await finalizeWebhookRun(runId, 'executed', 'openclaw_command_executed');
+    res.status(200).json({
+      status: 'executed',
+      eventId: payload.eventId,
+      runId,
+      chainId,
+      command: commandToken,
+      result,
+    });
+    return;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const publicError = 'execution_failed';
+    const isUnsupported = error instanceof UnsupportedOpenClawCommandError;
+    const publicError = isUnsupported ? 'unsupported_command' : 'execution_failed';
     await registerWebhookFailure(chainId, runId, message);
-    await finalizeWebhookRun(runId, 'paused', 'openclaw_bridge_error');
+    await finalizeWebhookRun(runId, 'paused', isUnsupported ? 'command_not_allowed' : 'openclaw_bridge_error');
 
-    res.status(500).json({
-      status: 'execution_failed',
+    res.status(isUnsupported ? 501 : 500).json({
+      status: publicError,
       eventId: payload.eventId,
       runId,
       chainId,


### PR DESCRIPTION
## Summary\n- introduce explicit OpenClaw command registry with capability classes (ead_only, 
eeds_approval, mutating)\n- add new read-only commands: /metrics, /runs [limit], /events <runId> [limit]\n- enforce capability-aware policy by deriving mutating behavior from command capability\n- add deterministic unsupported response (501 unsupported_command) for allowlisted-but-unimplemented commands\n- keep blocked unknown commands deterministic (locked_policy)\n\n## Validation\n- npm run type-check\n- npm run lint (warnings-only baseline)\n- npm test -- src/routes/openclaw.test.ts\n- npm test\n- npm run build\n\n## Docs/Artifacts\n- Plan: .agent/plans/40-openclaw-v2-curated-commands.md\n- Execution report: .agent/reports/execution-reports/2026-02-04-40-openclaw-v2-curated-commands.md\n- Analysis doc: docs/OpenClaw/analysis/openclaw-v2-curated-commands.md\n\nFixes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced OpenClaw v2 curated commands with explicit capabilities (read-only, approval-required, mutating)
  * Added new read-only endpoints: /metrics, /runs (with limits), and /events (redacted-safe subset)
  * Implemented capability-aware policy routing and deterministic handling for unsupported/mutating commands

* **Documentation**
  * Added comprehensive OpenClaw v2 architecture and policy evaluation docs

* **Tests**
  * Expanded tests covering new endpoints, approval/mutating flows, and deterministic error responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->